### PR TITLE
fix: support idrac10 quirks + lenovo bios bug fix

### DIFF
--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -393,7 +393,7 @@ impl Redfish for Bmc {
         );
         attributes.insert(
             "DevicesandIOPorts_SerialPortAccessMode",
-            EnabledDisabled::Enabled.to_string(),
+            "Shared".to_string(),
         );
 
         // Only in older Lenovo systems

--- a/src/model/oem/dell.rs
+++ b/src/model/oem/dell.rs
@@ -246,12 +246,14 @@ pub struct MachineBiosAttrs {
     pub serial_port_address: SerialPortSettings,
     pub fail_safe_baud: String,
     pub con_term_type: SerialPortTermSettings,
-    pub redir_after_boot: EnabledDisabled,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redir_after_boot: Option<EnabledDisabled>,
     pub sriov_global_enable: EnabledDisabled,
     pub tpm_security: OnOff,
     pub tpm2_hierarchy: Tpm2HierarchySettings,
     pub tpm2_algorithm: Tpm2Algorithm,
-    pub boot_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub boot_mode: Option<String>,
     #[serde(rename = "HttpDev1EnDis")]
     pub http_device_1_enabled_disabled: EnabledDisabled,
     #[serde(rename = "PxeDev1EnDis")]


### PR DESCRIPTION
**Dell iDRAC 10 Compatibility**
Updated the following attributes to be optional, as they are missing or restricted in iDRAC 10:

- `RedirAfterBoot`
- `OS-BMC.1.AdminState`
- `BootMode`: Now optional/read-only to support UEFI-only hardware (iDRAC 10), while maintaining write support for iDRAC 9.

**Lenovo Bug Fix**
Corrected the `DevicesandIOPorts_SerialPortAccessMode` attribute. The setting now correctly uses `Shared` instead of the invalid `Enabled` value.