### PR TITLE
feat: further support for newer iDRAC BIOS/UEFI password configuration

### DIFF
--- a/src/model/oem/dell.rs
+++ b/src/model/oem/dell.rs
@@ -290,7 +290,8 @@ pub struct BiosSerialAttrs {
     pub ext_serial_connector: SerialPortExtSettings,
     pub fail_safe_baud: String,
     pub con_term_type: SerialPortTermSettings,
-    pub redir_after_boot: EnabledDisabled,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redir_after_boot: Option<EnabledDisabled>, // Not available in iDRAC 10
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -303,9 +304,11 @@ pub struct SetBiosSerialAttrs {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub enum SerialCommSettings {
-    OnConRedir, // preferred
+    OnConRedir,      // iDRAC 9 - preferred
     OnNoConRedir,
-    OnConRedirAuto, // PowerEdge R640
+    OnConRedirAuto,  // newer iDRAC - preferred
+    OnConRedirCom1,  // newer iDRAC
+    OnConRedirCom2,  // newer iDRAC
     Off,
 }
 
@@ -322,6 +325,8 @@ impl FromStr for SerialCommSettings {
             "OnConRedir" => Ok(Self::OnConRedir),
             "OnNoConRedir" => Ok(Self::OnNoConRedir),
             "OnConRedirAuto" => Ok(Self::OnConRedirAuto),
+            "OnConRedirCom1" => Ok(Self::OnConRedirCom1),
+            "OnConRedirCom2" => Ok(Self::OnConRedirCom2),
             "Off" => Ok(Self::Off),
             x => Err(InvalidValueError(format!(
                 "Invalid SerialCommSettings value: {x}"
@@ -332,8 +337,10 @@ impl FromStr for SerialCommSettings {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Eq, PartialEq)]
 pub enum SerialPortSettings {
-    Com1, // preferred
-    Com2,
+    Com1,                    // legacy preferred
+    Com2,                    // legacy
+    Serial1Com1Serial2Com2,  // newer BIOS: SD1=COM1, SD2=COM2
+    Serial1Com2Serial2Com1,  // newer BIOS: SD1=COM2, SD2=COM1 (preferred for SOL)
 }
 
 impl fmt::Display for SerialPortSettings {


### PR DESCRIPTION
## Problems

When running `machine-setup-status` and `machine-setup` commands on Dell servers with newer iDRAC 10 firmware, several errors occurred due to changes in the Redfish API:

**Error 1: SerialPortAddress deserialization failure**

```
Could not deserialize response from bios. Body: "Serial1Com2Serial2Com1". unknown variant `Serial1Com2Serial2Com1`, expected `Com1` or `Com2`
```

**Error 2: SerialComm invalid value**

```
Unable to set the object properties because an incorrect object value is entered. MessageArgs: ["SerialComm"]
```

The newer BIOS only accepts `OnConRedirAuto`, `OnConRedirCom1`, `OnConRedirCom2` instead of `OnConRedir`.

**Error 3: Jobs endpoint 404**

```
HTTP 404 Not Found at https://10.217.155.84:443/redfish/v1/Managers/iDRAC.Embedded.1/Jobs
```

**Error 4: RedirAfterBoot not available**

The `RedirAfterBoot` BIOS attribute doesn't exist in iDRAC 10.

## Changes

**1. Added new SerialPortSettings enum variants** (`model/oem/dell.rs`)
- `Serial1Com1Serial2Com2` - newer BIOS format (SD1=COM1, SD2=COM2)
- `Serial1Com2Serial2Com1` - newer BIOS format (SD1=COM2, SD2=COM1, preferred for SOL)

**2. Added new SerialCommSettings enum variants** (`model/oem/dell.rs`)
- `OnConRedirCom1` - newer iDRAC
- `OnConRedirCom2` - newer iDRAC

**3. Made BiosSerialAttrs.redir_after_boot optional** (`model/oem/dell.rs`)
- Added `#[serde(skip_serializing_if = "Option::is_none")]` since iDRAC 10 doesn't have this attribute

**4. Added iDRAC version handling** (`dell.rs`)
- Automatically use appropriate values for both `SerialPortAddress` and `SerialComm` based on detection

**5. Updated Jobs endpoint path** (`dell.rs`)
- Changed `get_job_state` and `create_bios_config_job` to use `Managers/iDRAC.Embedded.1/Oem/Dell/Jobs`
- Verified this is backwards compatible with iDRAC9

**6. Updated clear_uefi_password** (`dell.rs`)
- Try regular `change_uefi_password` method first (like other vendors)
- Fall back to `ImportSystemConfiguration` hack only if regular method fails