### PR TITLE
fix: limit pxe retry to 3 for AMI + support different GB200 product name

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -1058,6 +1058,7 @@ impl Bmc {
         HashMap::from([
             ("VMXEN".to_string(), "Enable".into()), // VMX (Intel Virtualization)
             ("PCIS007".to_string(), "Enabled".into()), // SR-IOV Support
+            ("LEM0001".to_string(), 3.into()),      // PXE retry count (remove on future FW update)
             ("NWSK000".to_string(), "Enabled".into()), // Network Stack
             ("NWSK001".to_string(), "Disabled".into()), // IPv4 PXE Support
             ("NWSK006".to_string(), "Enabled".into()), // IPv4 HTTP Support

--- a/src/model/service_root.rs
+++ b/src/model/service_root.rs
@@ -106,7 +106,7 @@ impl ServiceRoot {
             }
             "nvidia" => match self.product.as_deref() {
                 Some("P3809") => RedfishVendor::P3809, // could be gh200 compute or nvswitch
-                Some("GB200 NVL") => RedfishVendor::NvidiaGBx00,
+                Some("GB200 NVL") | Some("GB BMC") => RedfishVendor::NvidiaGBx00,
                 _ => RedfishVendor::NvidiaDpu,
             },
             "wiwynn" => RedfishVendor::NvidiaGBx00,
@@ -127,12 +127,32 @@ impl ServiceRoot {
 
 #[cfg(test)]
 mod test {
-    use crate::model::service_root::RedfishVendor;
+    use crate::model::service_root::{RedfishVendor, ServiceRoot};
 
     #[test]
     fn test_supermicro_service_root() {
         let data = include_str!("testdata/supermicro_service_root.json");
         let result: super::ServiceRoot = serde_json::from_str(data).unwrap();
         assert_eq!(result.vendor().unwrap(), RedfishVendor::Supermicro);
+    }
+
+    #[test]
+    fn test_nvidia_gb_bmc_service_root() {
+        let result = ServiceRoot {
+            vendor: Some("NVIDIA".to_string()),
+            product: Some("GB BMC".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::NvidiaGBx00);
+    }
+
+    #[test]
+    fn test_nvidia_bluefield_service_root() {
+        let result = ServiceRoot {
+            vendor: Some("NVIDIA".to_string()),
+            product: Some("BlueField-3".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::NvidiaDpu);
     }
 }


### PR DESCRIPTION
This PR addresses two issues:

- AMI hosts could keep retrying PXE boot even after the PXE server sent an exit command. Retries are now capped at 3 attempts before continuing to the next boot option (temporary behavior until newer Lenovo firmware fixes this).
- GB200 compute trays could be misclassified as DPU BMCs due to service root product naming. `Vendor: NVIDIA` with `Product: GB BMC` is now recognized as a GB200.