### PR TITLE
feat(standard): implement boot_once/boot_first/set_boot_override

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -27,10 +27,7 @@ use crate::{
     jsonmap,
     model::{
         account_service::ManagerAccount,
-        boot::{
-            self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
-            BootSourceOverrideTarget,
-        },
+        boot::{self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode},
         certificate::Certificate,
         chassis::{Assembly, Chassis, NetworkAdapter},
         component_integrity::ComponentIntegrities,
@@ -710,15 +707,10 @@ impl Redfish for Bmc {
 
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            let override_target = match target {
-                Boot::Pxe => BootSourceOverrideTarget::Pxe,
-                Boot::HardDisk => BootSourceOverrideTarget::Hdd,
-                Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
-            };
             Redfish::set_boot_override(
                 self,
                 BootOverride {
-                    target: override_target,
+                    target: target.into(),
                     enabled: BootSourceOverrideEnabled::Once,
                     mode: None,
                     http_boot_uri: None,

--- a/src/model/boot.rs
+++ b/src/model/boot.rs
@@ -104,6 +104,18 @@ impl fmt::Display for BootSourceOverrideTarget {
     }
 }
 
+/// Maps the simple [`crate::Boot`] enum used by `boot_once` / `boot_first`
+/// to the richer `BootSourceOverrideTarget` consumed by `set_boot_override`.
+impl From<crate::Boot> for BootSourceOverrideTarget {
+    fn from(target: crate::Boot) -> Self {
+        match target {
+            crate::Boot::Pxe => BootSourceOverrideTarget::Pxe,
+            crate::Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+            crate::Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum BootSourceOverrideMode {

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -26,7 +26,7 @@ use reqwest::{header::HeaderName, Method, StatusCode};
 use serde_json::json;
 use tracing::debug;
 
-use crate::model::boot::{self, BootSourceOverrideEnabled, BootSourceOverrideTarget};
+use crate::model::boot::{self, BootSourceOverrideEnabled};
 use crate::model::certificate::Certificate;
 use crate::model::chassis::Assembly;
 use crate::model::component_integrity::ComponentIntegrities;
@@ -412,15 +412,12 @@ impl Redfish for RedfishStandard {
 
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            Redfish::set_boot_override(
-                self,
-                BootOverride {
-                    target: boot_target_from(target),
-                    enabled: BootSourceOverrideEnabled::Once,
-                    mode: None,
-                    http_boot_uri: None,
-                },
-            )
+            self.set_boot_override(BootOverride {
+                target: target.into(),
+                enabled: BootSourceOverrideEnabled::Once,
+                mode: None,
+                http_boot_uri: None,
+            })
             .await?;
             Ok(())
         })
@@ -431,15 +428,12 @@ impl Redfish for RedfishStandard {
         target: Boot,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            Redfish::set_boot_override(
-                self,
-                BootOverride {
-                    target: boot_target_from(target),
-                    enabled: BootSourceOverrideEnabled::Continuous,
-                    mode: None,
-                    http_boot_uri: None,
-                },
-            )
+            self.set_boot_override(BootOverride {
+                target: target.into(),
+                enabled: BootSourceOverrideEnabled::Continuous,
+                mode: None,
+                http_boot_uri: None,
+            })
             .await?;
             Ok(())
         })
@@ -1290,16 +1284,6 @@ impl Redfish for RedfishStandard {
         servers: &'a [String],
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.set_manager_ntp_servers(servers).await })
-    }
-}
-
-/// Map the simple `Boot` enum used by `boot_once` / `boot_first` to the
-/// richer `BootSourceOverrideTarget` consumed by `set_boot_override`.
-fn boot_target_from(target: Boot) -> BootSourceOverrideTarget {
-    match target {
-        Boot::Pxe => BootSourceOverrideTarget::Pxe,
-        Boot::HardDisk => BootSourceOverrideTarget::Hdd,
-        Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
     }
 }
 

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -26,6 +26,7 @@ use reqwest::{header::HeaderName, Method, StatusCode};
 use serde_json::json;
 use tracing::debug;
 
+use crate::model::boot::{self, BootSourceOverrideEnabled, BootSourceOverrideTarget};
 use crate::model::certificate::Certificate;
 use crate::model::chassis::Assembly;
 use crate::model::component_integrity::ComponentIntegrities;
@@ -409,25 +410,58 @@ impl Redfish for RedfishStandard {
         })
     }
 
-    fn boot_once<'a>(
-        &'a self,
-        _target: Boot,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { Err(RedfishError::NotSupported("boot_once".to_string())) })
+    fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: boot_target_from(target),
+                    enabled: BootSourceOverrideEnabled::Once,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
+        })
     }
 
     fn boot_first<'a>(
         &'a self,
-        _target: Boot,
+        target: Boot,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { Err(RedfishError::NotSupported("boot_first".to_string())) })
+        Box::pin(async move {
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: boot_target_from(target),
+                    enabled: BootSourceOverrideEnabled::Continuous,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
+        })
     }
 
     fn set_boot_override<'a>(
         &'a self,
-        _settings: BootOverride,
+        settings: BootOverride,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { Err(RedfishError::NotSupported("set_boot_override".to_string())) })
+        Box::pin(async move {
+            let boot = boot::Boot {
+                boot_source_override_target: Some(settings.target),
+                boot_source_override_enabled: Some(settings.enabled),
+                boot_source_override_mode: settings.mode,
+                http_boot_uri: settings.http_boot_uri,
+                ..Default::default()
+            };
+            let body = HashMap::from([("Boot", boot)]);
+            let url = format!("Systems/{}", self.system_id());
+            self.client.patch(&url, body).await?;
+            Ok(None)
+        })
     }
 
     fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -1256,6 +1290,16 @@ impl Redfish for RedfishStandard {
         servers: &'a [String],
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.set_manager_ntp_servers(servers).await })
+    }
+}
+
+/// Map the simple `Boot` enum used by `boot_once` / `boot_first` to the
+/// richer `BootSourceOverrideTarget` consumed by `set_boot_override`.
+fn boot_target_from(target: Boot) -> BootSourceOverrideTarget {
+    match target {
+        Boot::Pxe => BootSourceOverrideTarget::Pxe,
+        Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+        Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
     }
 }
 

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -29,10 +29,7 @@ use tokio::fs::File;
 use crate::{
     model::{
         account_service::ManagerAccount,
-        boot::{
-            self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
-            BootSourceOverrideTarget,
-        },
+        boot::{self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode},
         certificate::Certificate,
         chassis::{Assembly, Chassis, NetworkAdapter},
         component_integrity::ComponentIntegrities,
@@ -505,11 +502,7 @@ impl Redfish for Bmc {
             Redfish::set_boot_override(
                 self,
                 BootOverride {
-                    target: match target {
-                        Boot::Pxe => BootSourceOverrideTarget::Pxe,
-                        Boot::HardDisk => BootSourceOverrideTarget::Hdd,
-                        Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
-                    },
+                    target: target.into(),
                     enabled: BootSourceOverrideEnabled::Once,
                     mode: None,
                     http_boot_uri: None,
@@ -535,11 +528,7 @@ impl Redfish for Bmc {
                     Redfish::set_boot_override(
                         self,
                         BootOverride {
-                            target: match target {
-                                Boot::Pxe => BootSourceOverrideTarget::Pxe,
-                                Boot::HardDisk => BootSourceOverrideTarget::Hdd,
-                                Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
-                            },
+                            target: target.into(),
                             enabled: BootSourceOverrideEnabled::Continuous,
                             mode: None,
                             http_boot_uri: None,


### PR DESCRIPTION
These were NotSupported stubs on the generic RedfishStandard. Implement set_boot_override by PATCHing Systems/{id} with a Boot object; boot_once and boot_first delegate to it with Once/Continuous. A boot_target_from helper maps the Boot enum onto BootSourceOverrideTarget.