### PR TITLE
feat: add Redfish::initialize() to resolve system/manager IDs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,12 @@ pub type RedfishFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Interface to a BMC Redfish server. All calls will include one or more HTTP network calls.
 pub trait Redfish: Send + Sync + 'static {
+    /// Populate IDs needed by `Managers/{id}` / `Systems/{id}` URL builders.
+    /// Vendor wrappers are pre-initialised, so default is a no-op.
+    fn initialize<'a>(&'a mut self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { Ok(()) })
+    }
+
     /// Rename a user
     fn change_username<'a>(
         &'a self,

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -69,6 +69,10 @@ pub struct RedfishStandard {
     service_root: ServiceRoot,
 }
 impl Redfish for RedfishStandard {
+    fn initialize<'a>(&'a mut self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(RedfishStandard::initialize(self))
+    }
+
     fn create_user<'a>(
         &'a self,
         username: &'a str,
@@ -1364,6 +1368,32 @@ impl RedfishStandard {
             vendor: None,
             service_root: default::Default::default(),
         }
+    }
+
+    /// Fetch service root + system/manager id; populate
+    /// `manager_id` / `system_id` / `service_root`.
+    pub async fn initialize(&mut self) -> Result<(), RedfishError> {
+        let service_root = self.get_service_root().await?;
+        let systems = self.get_systems().await?;
+        let managers = self.get_managers().await?;
+        // Prefer the canonical host system `System_0`, matching the selection
+        // `RedfishClientPool::create_client` makes: some platforms enumerate an
+        // auxiliary system (e.g. the NVIDIA `HGX_Baseboard_0`) ahead of the real
+        // host, so taking the first member blindly targets the wrong system.
+        let system_id = systems
+            .iter()
+            .find(|id| *id == "System_0")
+            .or_else(|| systems.first())
+            .ok_or_else(|| RedfishError::GenericError {
+                error: "No systems found in service root".to_string(),
+            })?;
+        let manager_id = managers.first().ok_or_else(|| RedfishError::GenericError {
+            error: "No managers found in service root".to_string(),
+        })?;
+        self.set_system_id(system_id)?;
+        self.set_manager_id(manager_id)?;
+        self.set_service_root(service_root)?;
+        Ok(())
     }
 
     pub fn system_id(&self) -> &str {


### PR DESCRIPTION
Nothing populated the Systems/{id} and Managers/{id} IDs for a plain RedfishStandard. Add an initialize() trait method, defaulting to a no-op so vendor wrappers are unaffected, and implement it for RedfishStandard: fetch the service root and the first system/manager IDs and store them.