### PR TITLE
feat: enabling routing for Supermicro GB300s

### DIFF
--- a/src/model/service_root.rs
+++ b/src/model/service_root.rs
@@ -111,7 +111,10 @@ impl ServiceRoot {
                 _ => RedfishVendor::NvidiaDpu,
             },
             "wiwynn" => RedfishVendor::NvidiaGBx00,
-            "supermicro" => RedfishVendor::Supermicro,
+            "supermicro" => match self.product.as_deref() {
+                Some("GB NVL") => RedfishVendor::NvidiaGBx00,
+                _ => RedfishVendor::Supermicro,
+            },
             "lite-on technology corp." => RedfishVendor::LiteOnPowerShelf,
             "delta" => RedfishVendor::DeltaPowerShelf,
             _ => RedfishVendor::Unknown,
@@ -135,6 +138,29 @@ mod test {
     fn test_supermicro_service_root() {
         let data = include_str!("testdata/supermicro_service_root.json");
         let result: super::ServiceRoot = serde_json::from_str(data).unwrap();
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::Supermicro);
+    }
+
+    #[test]
+    fn test_supermicro_gb300_service_root() {
+        // Supermicro GB300 NVL exposes an OpenBMC/NVIDIA GB tree, so it must route
+        // to the shared GB implementation rather than the AMI Supermicro path.
+        let result = ServiceRoot {
+            vendor: Some("Supermicro".to_string()),
+            product: Some("GB NVL".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::NvidiaGBx00);
+    }
+
+    #[test]
+    fn test_supermicro_non_gb_service_root() {
+        // A classic Supermicro (no GB NVL product) still uses the Supermicro path.
+        let result = ServiceRoot {
+            vendor: Some("Supermicro".to_string()),
+            product: Some("SYS-821GE-TNHR".to_string()),
+            ..Default::default()
+        };
         assert_eq!(result.vendor().unwrap(), RedfishVendor::Supermicro);
     }
 

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1340,6 +1340,23 @@ impl Redfish for Bmc {
 }
 
 impl Bmc {
+    /// Returns true if this is a GB300 platform.
+    ///
+    /// The host system model (e.g."GB NVL") can be too vague, so detect via the HGX
+    /// baseboard model ("GB300 ...").
+    async fn is_gb300(&self) -> Result<bool, RedfishError> {
+        let systems: Vec<ComputerSystem> = self
+            .get_collection(ODataId {
+                odata_id: "/redfish/v1/Systems".to_string(),
+            })
+            .await
+            .and_then(|c| c.try_get::<ComputerSystem>())?
+            .members;
+        Ok(systems
+            .iter()
+            .any(|s| s.model.as_deref().unwrap_or_default().contains("GB300")))
+    }
+
     /// Check BIOS and BMC attributes and return differences
     async fn diff_bios_bmc_attr(&self) -> Result<Vec<MachineSetupDiff>, RedfishError> {
         let mut diffs = vec![];

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1344,6 +1344,7 @@ impl Bmc {
     ///
     /// The host system model (e.g."GB NVL") can be too vague, so detect via the HGX
     /// baseboard model ("GB300 ...").
+    #[allow(dead_code)]
     async fn is_gb300(&self) -> Result<bool, RedfishError> {
         let systems: Vec<ComputerSystem> = self
             .get_collection(ODataId {


### PR DESCRIPTION
The Supermicro GB300 reports `Vendor: "Supermicro"`, so it was getting sent to the `supermicro.rs` path. But it's actually an **OpenBMC** box running the same GB Redfish tree as GB200 which `nvidia_gbx00` already handles. This sends it there instead.

Evidence (from the tray dump):
- Service root: `Vendor: "Supermicro"`, `Product: "GB NVL"` but `Managers/BMC_0` is `"OpenBmc"`, not an Supermicro BMC.
- No `Oem/Supermicro` anywhere
- Same GB200 shape: `System_0` + `HGX_Baseboard_0`, standard `Bios/Settings`, etc

Changes:
- `service_root.rs`: `Supermicro` + `GB NVL` → `NvidiaGBx00`
- `nvidia_gbx00.rs`: add a vendor-agnostic `is_gb300()` helper. Groundwork for the GB300-specific tweaks, not wired up yet.
   - Both Supermicro and Lenovo present `GB300 1CPU:2GPU Board PC` in the `HGX_Baseboard_0` system model