### PR TITLE
feat: add lenovo GB300 support

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -507,12 +507,7 @@ impl Redfish for Bmc {
                     ("LockdownBiosUpgradeDowngrade", value),
                 ]);
                 let config_bmc_url = format!("Managers/{}/Oem/ConfigBMC", self.s.manager_id());
-                return self
-                    .s
-                    .client
-                    .post(&config_bmc_url, body)
-                    .await
-                    .map(|_| ());
+                return self.s.client.post(&config_bmc_url, body).await.map(|_| ());
             }
 
             // LenovoGB300 has neither the OEM ConfigBMC endpoint nor

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -57,6 +57,26 @@ use crate::{
 /// AMI uses BIOS attribute SETUP001 for Administrator Password (UEFI password)
 const UEFI_PASSWORD_NAME: &str = "SETUP001";
 
+/// LenovoGB300 has no "EndlessBoot" BIOS attribute; infinite
+/// boot is expressed via the LEM0003 boot-retry count, where 50 is the
+/// firmware's representation for endless retries.
+const GB300_INFINITE_BOOT_RETRY: i64 = 50;
+
+/// Build a lockdown `Status` from the fully-locked / fully-unlocked booleans,
+/// defaulting to `Partial` when the readout is neither.
+fn lockdown_status_from(message: String, is_locked: bool, is_unlocked: bool) -> Status {
+    Status {
+        message,
+        status: if is_locked {
+            StatusInternal::Enabled
+        } else if is_unlocked {
+            StatusInternal::Disabled
+        } else {
+            StatusInternal::Partial
+        },
+    }
+}
+
 pub struct Bmc {
     s: RedfishStandard,
 }
@@ -64,6 +84,58 @@ pub struct Bmc {
 impl Bmc {
     pub fn new(s: RedfishStandard) -> Result<Bmc, RedfishError> {
         Ok(Bmc { s })
+    }
+
+    /// Serial-console BIOS attributes as `(key, enabled_value, disabled_value)`.
+    /// A `disabled_value` of "any" means any value counts as correctly disabled.
+    ///
+    /// LenovoGB300's BIOS registry mostly prefixes enum values with the
+    /// attribute id, but irregularly: TER001/TER010 stay bare, the port is COM0
+    /// not COM1, and the hyphen in VT-UTF8 is dropped. So both forms are listed
+    /// explicitly per attribute rather than derived via a prefix rule.
+    fn serial_console_attrs(&self) -> Vec<(&'static str, &'static str, &'static str)> {
+        let gb300 = self.s.vendor == Some(RedfishVendor::LenovoGB300);
+        // (key, generic_enabled, gb300_enabled, disabled)
+        const ATTRS: &[(&str, &str, &str, &str)] = &[
+            ("TER001", "Enabled", "Enabled", "Disabled"), // Console Redirection
+            ("TER010", "Enabled", "Enabled", "Disabled"), // Console Redirection EMS
+            ("TER06B", "COM1", "TER06BCOM0", "any"),      // Out-of-Band Mgmt Port
+            ("TER0021", "115200", "TER0021115200", "any"), // Bits per second
+            ("TER0020", "115200", "TER0020115200", "any"), // Bits per second EMS
+            ("TER012", "VT100Plus", "TER012VT100Plus", "any"), // Terminal Type
+            ("TER011", "VT-UTF8", "TER011VTUTF8", "any"), // Terminal Type EMS
+            ("TER05D", "None", "TER05DNone", "any"),      // Flow Control
+        ];
+        ATTRS
+            .iter()
+            .map(|&(key, generic, gb300_val, disabled)| {
+                (key, if gb300 { gb300_val } else { generic }, disabled)
+            })
+            .collect()
+    }
+
+    /// LenovoGB300 lockdown status: USB support (attribute-id prefixed enum,
+    /// e.g. "USB000Disabled") plus the host interface. There is no KCS BIOS
+    /// attribute on this platform, so it is not part of the status.
+    async fn lockdown_status_gb300(&self) -> Result<Status, RedfishError> {
+        let bios = self.s.bios().await?;
+        let url = format!("Systems/{}/Bios", self.s.system_id());
+        let attrs = jsonmap::get_object(&bios, "Attributes", &url)?;
+        let usb000 = jsonmap::get_str(attrs, "USB000", "Bios Attributes")?;
+
+        let hi_url = format!("Managers/{}/HostInterfaces/Self", self.s.manager_id());
+        let (_status, hi): (_, serde_json::Value) = self.s.client.get(&hi_url).await?;
+        let hi_enabled = hi
+            .get("InterfaceEnabled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let message = format!("usb_support={usb000}, host_interface={hi_enabled}");
+
+        let is_locked = usb000 == "USB000Disabled" && !hi_enabled;
+        let is_unlocked = usb000 == "USB000Enabled" && hi_enabled;
+
+        Ok(lockdown_status_from(message, is_locked, is_unlocked))
     }
 
     /// LenovoAMI-specific lockdown status via OEM ConfigBMC endpoint.
@@ -75,8 +147,8 @@ impl Bmc {
             "LockdownBiosUpgradeDowngrade",
         ];
 
-        let (_status, body): (_, serde_json::Value) =
-            self.s.client.get("Managers/Self/Oem/ConfigBMC").await?;
+        let config_bmc_url = format!("Managers/{}/Oem/ConfigBMC", self.s.manager_id());
+        let (_status, body): (_, serde_json::Value) = self.s.client.get(&config_bmc_url).await?;
 
         let values: Vec<&str> = LOCKDOWN_FIELDS
             .iter()
@@ -93,16 +165,7 @@ impl Bmc {
         let is_locked = values.iter().all(|&v| v == "Enable");
         let is_unlocked = values.iter().all(|&v| v == "Disable");
 
-        Ok(Status {
-            message,
-            status: if is_locked {
-                StatusInternal::Enabled
-            } else if is_unlocked {
-                StatusInternal::Disabled
-            } else {
-                StatusInternal::Partial
-            },
-        })
+        Ok(lockdown_status_from(message, is_locked, is_unlocked))
     }
 }
 impl Redfish for Bmc {
@@ -443,37 +506,54 @@ impl Redfish for Bmc {
                     ("LockdownBiosSettingsChange", value),
                     ("LockdownBiosUpgradeDowngrade", value),
                 ]);
+                let config_bmc_url = format!("Managers/{}/Oem/ConfigBMC", self.s.manager_id());
                 return self
                     .s
                     .client
-                    .post("Managers/Self/Oem/ConfigBMC", body)
+                    .post(&config_bmc_url, body)
                     .await
                     .map(|_| ());
             }
 
-            let (kcsacp, usb, hi_enabled) = match target {
-                Enabled => ("Deny All", "Disabled", false),
-                Disabled => ("Allow All", "Enabled", true),
+            // LenovoGB300 has neither the OEM ConfigBMC endpoint nor
+            // the generic AMI `KCSACP` BIOS attribute, and its USB enum values
+            // are attribute-id prefixed (e.g. "USB000Disabled").
+            let hi_enabled = target == Disabled;
+            let bios_attrs = if self.s.vendor == Some(RedfishVendor::LenovoGB300) {
+                let usb = match target {
+                    Enabled => "USB000Disabled",
+                    Disabled => "USB000Enabled",
+                };
+                HashMap::from([("USB000".to_string(), usb.into())])
+            } else {
+                let (kcsacp, usb) = match target {
+                    Enabled => ("Deny All", "Disabled"),
+                    Disabled => ("Allow All", "Enabled"),
+                };
+                HashMap::from([
+                    ("KCSACP".to_string(), kcsacp.into()),
+                    ("USB000".to_string(), usb.into()),
+                ])
             };
-            self.set_bios(HashMap::from([
-                ("KCSACP".to_string(), kcsacp.into()),
-                ("USB000".to_string(), usb.into()),
-            ]))
-            .await?;
+            self.set_bios(bios_attrs).await?;
+
+            let hi_url = format!("Managers/{}/HostInterfaces/Self", self.s.manager_id());
             let hi_body = HashMap::from([("InterfaceEnabled", hi_enabled)]);
-            self.s
-                .client
-                .patch_with_if_match("Managers/Self/HostInterfaces/Self", hi_body)
-                .await
+            self.s.client.patch_with_if_match(&hi_url, hi_body).await
         })
     }
 
     /// AMI lockdown status - checks KCS access, USB support, and Host Interface.
-    /// On LenovoAMI, reads the OEM ConfigBMC endpoint instead.
+    /// On LenovoAMI, reads the OEM ConfigBMC endpoint instead. On LenovoGB300,
+    /// checks USB support and the host interface (no KCS/ConfigBMC there).
     fn lockdown_status<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Status, RedfishError>> {
         Box::pin(async move {
             if self.s.vendor == Some(RedfishVendor::LenovoAMI) {
                 return self.lockdown_status_lenovo_ami().await;
+            }
+
+            if self.s.vendor == Some(RedfishVendor::LenovoGB300) {
+                return self.lockdown_status_gb300().await;
             }
 
             let bios = self.s.bios().await?;
@@ -482,8 +562,8 @@ impl Redfish for Bmc {
             let kcsacp = jsonmap::get_str(attrs, "KCSACP", "Bios Attributes")?;
             let usb000 = jsonmap::get_str(attrs, "USB000", "Bios Attributes")?;
 
-            let hi_url = "Managers/Self/HostInterfaces/Self";
-            let (_status, hi): (_, serde_json::Value) = self.s.client.get(hi_url).await?;
+            let hi_url = format!("Managers/{}/HostInterfaces/Self", self.s.manager_id());
+            let (_status, hi): (_, serde_json::Value) = self.s.client.get(&hi_url).await?;
             let hi_enabled = hi
                 .get("InterfaceEnabled")
                 .and_then(|v| v.as_bool())
@@ -497,34 +577,18 @@ impl Redfish for Bmc {
             let is_locked = kcsacp == "Deny All" && usb000 == "Disabled" && !hi_enabled;
             let is_unlocked = kcsacp == "Allow All" && usb000 == "Enabled" && hi_enabled;
 
-            Ok(Status {
-                message,
-                status: if is_locked {
-                    StatusInternal::Enabled
-                } else if is_unlocked {
-                    StatusInternal::Disabled
-                } else {
-                    StatusInternal::Partial
-                },
-            })
+            Ok(lockdown_status_from(message, is_locked, is_unlocked))
         })
     }
 
     /// Setup serial console for AMI BMC via BIOS attributes.
     fn setup_serial_console<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            use serde_json::Value;
-
-            let attributes: HashMap<String, Value> = HashMap::from([
-                ("TER001".to_string(), "Enabled".into()), // Console Redirection
-                ("TER010".to_string(), "Enabled".into()), // Console Redirection EMS
-                ("TER06B".to_string(), "COM1".into()),    // Out-of-Band Mgmt Port
-                ("TER0021".to_string(), "115200".into()), // Bits per second
-                ("TER0020".to_string(), "115200".into()), // Bits per second EMS
-                ("TER012".to_string(), "VT100Plus".into()), // Terminal Type
-                ("TER011".to_string(), "VT-UTF8".into()), // Terminal Type EMS
-                ("TER05D".to_string(), "None".into()),    // Flow Control
-            ]);
+            let attributes: HashMap<String, serde_json::Value> = self
+                .serial_console_attrs()
+                .into_iter()
+                .map(|(key, enabled, _)| (key.to_string(), enabled.into()))
+                .collect();
 
             self.set_bios(attributes).await
         })
@@ -539,16 +603,7 @@ impl Redfish for Bmc {
             let url = format!("Systems/{}/Bios", self.s.system_id());
             let attrs = jsonmap::get_object(&bios, "Attributes", &url)?;
 
-            let expected = vec![
-                ("TER001", "Enabled", "Disabled"),
-                ("TER010", "Enabled", "Disabled"),
-                ("TER06B", "COM1", "any"),
-                ("TER0021", "115200", "any"),
-                ("TER0020", "115200", "any"),
-                ("TER012", "VT100Plus", "any"),
-                ("TER011", "VT-UTF8", "any"),
-                ("TER05D", "None", "any"),
-            ];
+            let expected = self.serial_console_attrs();
 
             let mut message = String::new();
             let mut enabled = true;
@@ -672,7 +727,15 @@ impl Redfish for Bmc {
 
     fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
-            self.set_bios(HashMap::from([("TCG006".to_string(), "TPM Clear".into())]))
+            // GB300's Grace BIOS registry prefixes the TCG006 enum value with
+            // the attribute id ("TCG006TPMClear"); other AMI platforms use the
+            // bare "TPM Clear".
+            let clear_value = if self.s.vendor == Some(RedfishVendor::LenovoGB300) {
+                "TCG006TPMClear"
+            } else {
+                "TPM Clear"
+            };
+            self.set_bios(HashMap::from([("TCG006".to_string(), clear_value.into())]))
                 .await
         })
     }
@@ -1047,8 +1110,8 @@ impl Redfish for Bmc {
         Box::pin(async move {
             let interface_enabled = target == EnabledDisabled::Disabled;
             let hi_body = HashMap::from([("InterfaceEnabled", interface_enabled)]);
-            let hi_url = "Managers/Self/HostInterfaces/Self";
-            self.s.client.patch_with_if_match(hi_url, hi_body).await
+            let hi_url = format!("Managers/{}/HostInterfaces/Self", self.s.manager_id());
+            self.s.client.patch_with_if_match(&hi_url, hi_body).await
         })
     }
 
@@ -1078,6 +1141,13 @@ impl Redfish for Bmc {
     /// AMI clear_nvram - sets RECV000 (Reset NVRAM) to "Enabled"
     fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
+            // The GB300 Grace BIOS registry has no RECV000 (Reset NVRAM)
+            // attribute, so there is no equivalent knob to set.
+            if self.s.vendor == Some(RedfishVendor::LenovoGB300) {
+                return Err(RedfishError::NotSupported(
+                    "clear_nvram: no RECV000 BIOS attribute on LenovoGB300".to_string(),
+                ));
+            }
             self.set_bios(HashMap::from([("RECV000".to_string(), "Enabled".into())]))
                 .await
         })
@@ -1098,6 +1168,14 @@ impl Redfish for Bmc {
 
     fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
+            if self.s.vendor == Some(RedfishVendor::LenovoGB300) {
+                return self
+                    .set_bios(HashMap::from([(
+                        "LEM0003".to_string(),
+                        GB300_INFINITE_BOOT_RETRY.into(),
+                    )]))
+                    .await;
+            }
             self.set_bios(HashMap::from([(
                 "EndlessBoot".to_string(),
                 "Enabled".into(),
@@ -1113,6 +1191,16 @@ impl Redfish for Bmc {
             let bios = self.s.bios().await?;
             let url = format!("Systems/{}/Bios", self.s.system_id());
             let attrs = jsonmap::get_object(&bios, "Attributes", &url)?;
+            if self.s.vendor == Some(RedfishVendor::LenovoGB300) {
+                // LEM0003 may be reported as a JSON number or a numeric string.
+                let Some(value) = attrs.get("LEM0003") else {
+                    return Ok(None);
+                };
+                let retry = value
+                    .as_i64()
+                    .or_else(|| value.as_str().and_then(|s| s.parse::<i64>().ok()));
+                return Ok(retry.map(|r| r == GB300_INFINITE_BOOT_RETRY));
+            }
             let endless_boot = jsonmap::get_str(attrs, "EndlessBoot", "Bios Attributes")?;
             Ok(Some(endless_boot == "Enabled"))
         })
@@ -1348,6 +1436,24 @@ impl Bmc {
 
     /// Get the BIOS attributes for machine setup.
     fn machine_setup_attrs(&self) -> HashMap<String, serde_json::Value> {
+        // The LenovoGB300 (Grace-based) uses a distinct BIOS registry: enum
+        // values are prefixed with the attribute ID (e.g. "PCIS007Enabled"),
+        // there is no Intel VMX knob (VMXEN) or boot-mode selector (FBO001),
+        // and "Infinite Boot" is expressed via the LEM0003 retry count (50 =
+        // endless boot) instead of the "EndlessBoot" attribute.
+        if self.s.vendor == Some(RedfishVendor::LenovoGB300) {
+            return HashMap::from([
+                ("PCIS007".to_string(), "PCIS007Enabled".into()), // SR-IOV Support
+                ("LEM0001".to_string(), 3.into()),                // PXE retry count
+                ("NWSK000".to_string(), "NWSK000Enabled".into()), // Network Stack
+                ("NWSK001".to_string(), "NWSK001Disabled".into()), // IPv4 PXE Support
+                ("NWSK006".to_string(), "NWSK006Enabled".into()), // IPv4 HTTP Support
+                ("NWSK002".to_string(), "NWSK002Disabled".into()), // IPv6 PXE Support
+                ("NWSK007".to_string(), "NWSK007Disabled".into()), // IPv6 HTTP Support
+                ("LEM0003".to_string(), GB300_INFINITE_BOOT_RETRY.into()), // Infinite Boot
+            ]);
+        }
+
         HashMap::from([
             ("VMXEN".to_string(), "Enable".into()), // VMX (Intel Virtualization)
             ("PCIS007".to_string(), "Enabled".into()), // SR-IOV Support

--- a/src/model/service_root.rs
+++ b/src/model/service_root.rs
@@ -61,6 +61,7 @@ pub struct ServiceRoot {
 pub enum RedfishVendor {
     Lenovo,
     LenovoAMI,
+    LenovoGB300,
     Dell,
     NvidiaDpu,
     Supermicro,

--- a/src/network.rs
+++ b/src/network.rs
@@ -32,7 +32,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, Instrument};
 
 use crate::model::service_root::RedfishVendor;
-use crate::model::{ComputerSystem, ODataId};
+use crate::model::ComputerSystem;
 use crate::{model::InvalidValueError, standard::RedfishStandard, Redfish, RedfishError};
 
 pub const REDFISH_ENDPOINT: &str = "redfish/v1";
@@ -246,12 +246,8 @@ impl RedfishClientPool {
         // fetched resources:
         // - P3809 is a placeholder — pick the GBx variant from chassis contents,
         //   whether it was auto-detected or explicitly provided.
-        // - AMI is shared by Viking/DGX/GB300. The "GB300" marker lives on the
-        //   NVIDIA HGX baseboard system (e.g. "GB300 1CPU:2GPU Board PC"), not
-        //   on the Lenovo host system (System_0, whose model is e.g.
-        //   "HG634N_V2"). So expand the whole Systems collection and inspect
-        //   every member: a Lenovo host alongside a GB300 board marks a Lenovo
-        //   GB300.
+        // - AMI is shared by Viking/DGX/GB300, distinguished by inspecting the
+        //   host systems (see `refine_ami_vendor`).
         let vendor = match vendor {
             RedfishVendor::P3809 => {
                 if chassis.contains(&"MGX_NVSwitch_0".to_string()) {
@@ -260,33 +256,32 @@ impl RedfishClientPool {
                     RedfishVendor::NvidiaGH200
                 }
             }
-            RedfishVendor::AMI => {
-                let all_systems: Vec<ComputerSystem> = s
-                    .get_collection(ODataId {
-                        odata_id: "/redfish/v1/Systems".to_string(),
-                    })
-                    .await
-                    .and_then(|c| c.try_get::<ComputerSystem>())?
-                    .members;
-                let is_lenovo = all_systems.iter().any(|sys| {
-                    sys.manufacturer
-                        .as_deref()
-                        .unwrap_or_default()
-                        .contains("Lenovo")
-                });
-                let is_gb300 = all_systems.iter().any(|sys| {
-                    sys.model.as_deref().unwrap_or_default().contains("GB300")
-                });
-                if is_lenovo && is_gb300 {
-                    RedfishVendor::LenovoGB300
-                } else {
-                    RedfishVendor::AMI
-                }
-            }
+            RedfishVendor::AMI => Self::refine_ami_vendor(&s).await?,
             other => other,
         };
 
         s.set_vendor(vendor).await
+    }
+
+    /// Refine a service-root `AMI` vendor to `LenovoGB300` when the host is a
+    /// Lenovo system alongside an NVIDIA GB300 baseboard; other AMI platforms
+    /// (Viking/DGX, plain AMI) stay `AMI`.
+    async fn refine_ami_vendor(s: &RedfishStandard) -> Result<RedfishVendor, RedfishError> {
+        let mut is_lenovo = false;
+        let mut is_gb300 = false;
+        for id in s.get_systems().await? {
+            let (_, system): (_, ComputerSystem) = s.client.get(&format!("Systems/{id}")).await?;
+            if system.manufacturer.as_deref().unwrap_or_default().contains("Lenovo") {
+                is_lenovo = true;
+            }
+            if system.model.as_deref().unwrap_or_default().contains("GB300") {
+                is_gb300 = true;
+            }
+            if is_lenovo && is_gb300 {
+                return Ok(RedfishVendor::LenovoGB300);
+            }
+        }
+        Ok(RedfishVendor::AMI)
     }
 
     /// Creates a Redfish BMC client for a certain endpoint

--- a/src/network.rs
+++ b/src/network.rs
@@ -271,10 +271,20 @@ impl RedfishClientPool {
         let mut is_gb300 = false;
         for id in s.get_systems().await? {
             let (_, system): (_, ComputerSystem) = s.client.get(&format!("Systems/{id}")).await?;
-            if system.manufacturer.as_deref().unwrap_or_default().contains("Lenovo") {
+            if system
+                .manufacturer
+                .as_deref()
+                .unwrap_or_default()
+                .contains("Lenovo")
+            {
                 is_lenovo = true;
             }
-            if system.model.as_deref().unwrap_or_default().contains("GB300") {
+            if system
+                .model
+                .as_deref()
+                .unwrap_or_default()
+                .contains("GB300")
+            {
                 is_gb300 = true;
             }
             if is_lenovo && is_gb300 {

--- a/src/network.rs
+++ b/src/network.rs
@@ -32,6 +32,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use tracing::{debug, Instrument};
 
 use crate::model::service_root::RedfishVendor;
+use crate::model::{ComputerSystem, ODataId};
 use crate::{model::InvalidValueError, standard::RedfishStandard, Redfish, RedfishError};
 
 pub const REDFISH_ENDPOINT: &str = "redfish/v1";
@@ -221,9 +222,19 @@ impl RedfishClientPool {
         // system id and set it before set_vendor (DGX detection depends on it).
         if vendor != RedfishVendor::DeltaPowerShelf {
             let systems = s.get_systems().await?;
-            let system_id = systems.first().ok_or_else(|| RedfishError::GenericError {
-                error: "No systems found in service root".to_string(),
-            })?;
+            // Prefer the canonical host system `System_0` when present. Some
+            // platforms enumerate an auxiliary system (e.g. the NVIDIA
+            // `HGX_Baseboard_0`) ahead of the real host, so picking the first
+            // member blindly targets the wrong system (no BIOS/boot). Falling
+            // back to the first member preserves behavior for every platform
+            // that does not expose `System_0` (e.g. Viking's `DGX`).
+            let system_id = systems
+                .iter()
+                .find(|id| *id == "System_0")
+                .or_else(|| systems.first())
+                .ok_or_else(|| RedfishError::GenericError {
+                    error: "No systems found in service root".to_string(),
+                })?;
             // call set_system_id always before calling set_vendor
             s.set_system_id(system_id)?;
         }
@@ -231,16 +242,48 @@ impl RedfishClientPool {
         s.set_manager_id(manager_id)?;
         s.set_service_root(service_root.clone())?;
 
-        // P3809 is a placeholder — always resolve it based on chassis
-        // contents, whether it was auto-detected or explicitly provided.
-        let vendor = if vendor == RedfishVendor::P3809 {
-            if chassis.contains(&"MGX_NVSwitch_0".to_string()) {
-                RedfishVendor::NvidiaGBSwitch
-            } else {
-                RedfishVendor::NvidiaGH200
+        // Resolve placeholder/ambiguous vendors that can only be settled from
+        // fetched resources:
+        // - P3809 is a placeholder — pick the GBx variant from chassis contents,
+        //   whether it was auto-detected or explicitly provided.
+        // - AMI is shared by Viking/DGX/GB300. The "GB300" marker lives on the
+        //   NVIDIA HGX baseboard system (e.g. "GB300 1CPU:2GPU Board PC"), not
+        //   on the Lenovo host system (System_0, whose model is e.g.
+        //   "HG634N_V2"). So expand the whole Systems collection and inspect
+        //   every member: a Lenovo host alongside a GB300 board marks a Lenovo
+        //   GB300.
+        let vendor = match vendor {
+            RedfishVendor::P3809 => {
+                if chassis.contains(&"MGX_NVSwitch_0".to_string()) {
+                    RedfishVendor::NvidiaGBSwitch
+                } else {
+                    RedfishVendor::NvidiaGH200
+                }
             }
-        } else {
-            vendor
+            RedfishVendor::AMI => {
+                let all_systems: Vec<ComputerSystem> = s
+                    .get_collection(ODataId {
+                        odata_id: "/redfish/v1/Systems".to_string(),
+                    })
+                    .await
+                    .and_then(|c| c.try_get::<ComputerSystem>())?
+                    .members;
+                let is_lenovo = all_systems.iter().any(|sys| {
+                    sys.manufacturer
+                        .as_deref()
+                        .unwrap_or_default()
+                        .contains("Lenovo")
+                });
+                let is_gb300 = all_systems.iter().any(|sys| {
+                    sys.model.as_deref().unwrap_or_default().contains("GB300")
+                });
+                if is_lenovo && is_gb300 {
+                    RedfishVendor::LenovoGB300
+                } else {
+                    RedfishVendor::AMI
+                }
+            }
+            other => other,
         };
 
         s.set_vendor(vendor).await

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -148,7 +148,7 @@ impl Redfish for RedfishStandard {
             // AMI BMC requires If-Match header for PATCH requests
             if matches!(
                 service_root.vendor(),
-                Some(RedfishVendor::AMI | RedfishVendor::LenovoAMI)
+                Some(RedfishVendor::AMI | RedfishVendor::LenovoAMI | RedfishVendor::LenovoGB300)
             ) {
                 self.client.patch_with_if_match(&url, &data).await
             } else {
@@ -1312,6 +1312,7 @@ impl RedfishStandard {
             RedfishVendor::Hpe => Ok(Box::new(crate::hpe::Bmc::new(self.clone())?)),
             RedfishVendor::Lenovo => Ok(Box::new(crate::lenovo::Bmc::new(self.clone())?)),
             RedfishVendor::LenovoAMI => Ok(Box::new(crate::ami::Bmc::new(self.clone())?)),
+            RedfishVendor::LenovoGB300 => Ok(Box::new(crate::ami::Bmc::new(self.clone())?)),
             RedfishVendor::NvidiaDpu => Ok(Box::new(crate::nvidia_dpu::Bmc::new(self.clone())?)),
             RedfishVendor::NvidiaGBx00 => {
                 Ok(Box::new(crate::nvidia_gbx00::Bmc::new(self.clone())?))
@@ -1708,7 +1709,7 @@ impl RedfishStandard {
 
         if matches!(
             self.vendor,
-            Some(RedfishVendor::AMI | RedfishVendor::LenovoAMI)
+            Some(RedfishVendor::AMI | RedfishVendor::LenovoAMI | RedfishVendor::LenovoGB300)
         ) {
             self.client.patch_with_if_match(&url, ntp_servers).await
         } else {


### PR DESCRIPTION
The Lenovo GB300 runs an AMI MegaRAC BMC but uses a distinct GB300 BIOS registry, so it gets its own vendor and AMI-client handling.

**Changes**
- New `RedfishVendor::LenovoGB300`, routed to `ami::Bmc` and added to the AMI `If-Match` groups.
- Detection (`network.rs`): refine `AMI` → `LenovoGB300` when a Lenovo host system is paired with an NVIDIA GB300 baseboard. Systems are fetched individually (the HGX baseboard returns null fields under `$expand`); also prefer `System_0` over the first member.
- GB300 behavior (`ami.rs`), verified against the BIOS registry:
  - Lockdown via `USB000` (prefixed enum) + host interface — no `ConfigBMC`/`KCSACP`.
  - Serial console, `clear_tpm` (`TCG006TPMClear`), and `machine_setup` use the GB300 prefixed enum values.
  - Infinite boot via `LEM0003=50` (no `EndlessBoot`); `clear_nvram` → `NotSupported` (no `RECV000`).
  - Host-interface/ConfigBMC URLs use the resolved manager id (`BMC_0`); shared `lockdown_status_from` helper.

**Testing**
Validated on a real Lenovo GB300 (detects as `LenovoGB300`, `System_0`/`BMC_0`; lockdown, machine-setup, boot-order functionality correct).
