### PR TITLE
fix(dell): match DPU HTTP boot option by name prefix, not exact equality

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -429,7 +429,7 @@ impl Redfish for Bmc {
                 let (expected, actual) = self
                     .get_expected_and_actual_first_boot_option(crate::BootInterfaceRef::Mac(mac))
                     .await?;
-                if expected.is_none() || expected != actual {
+                if !matches!((&expected, &actual), (Some(e), Some(a)) if a.starts_with(e)) {
                     diffs.push(MachineSetupDiff {
                         key: "boot_first".to_string(),
                         expected: expected.unwrap_or_else(|| "Not found".to_string()),
@@ -1146,7 +1146,7 @@ impl Redfish for Bmc {
                 .await?;
             let boot_order = self.get_boot_order().await?;
             for (idx, boot_option) in boot_order.iter().enumerate() {
-                if boot_option.display_name == expected_boot_option_name {
+                if boot_option.display_name.starts_with(&expected_boot_option_name) {
                     if idx == 0 {
                         // Dells will not generate a bios config job below if the boot orders already configured correctly
                         tracing::info!(
@@ -1358,7 +1358,7 @@ impl Redfish for Bmc {
             let (expected, actual) = self
                 .get_expected_and_actual_first_boot_option(boot_interface)
                 .await?;
-            Ok(expected.is_some() && expected == actual)
+            Ok(matches!((&expected, &actual), (Some(e), Some(a)) if a.starts_with(e)))
         })
     }
 


### PR DESCRIPTION
## Problem
`Dell::set_boot_order_dpu_first` (`src/dell.rs`) builds the expected boot option name as
`"HTTP Device 1: {DeviceDescription}"` and compares it for **exact equality** against each
boot option's `display_name`:

```rust
if boot_option.display_name == expected_boot_option_name {
```

On Dell iDRAC the real boot option name has an adapter/MAC/protocol suffix appended, e.g.:

```
HTTP Device 1: NIC in Slot 40 Port 1 Partition 1 - Nvidia Network Adapter - C4:70:BD:2C:3C:0A - IPv4
```

So the exact `==` never matches, the loop falls through to
`Err(RedfishError::MissingBootOption(..))`, and the boot order is never set. Downstream
(NICo / infra-controller) this wedges the host-provisioning state machine at `SetBootOrder`
indefinitely.

## Fix
Match by prefix — the constructed expected name is already a prefix of the real `display_name`:

```rust
if boot_option.display_name.starts_with(&expected_boot_option_name) {
```

The reorder action itself (`PATCH Boot.BootOrder=[id]`) is unchanged.

## Testing / verification
Reproduced and verified on a live **BlueField-3 + Dell PowerEdge XE9680 (iDRAC)**:
- **Before:** `set_boot_order_dpu_first` returned `MissingBootOption("HTTP Device 1: NIC in Slot 40 Port 1 Partition 1")` even though that boot option existed (`Boot0000`, with the suffix above) and was settable — confirmed by a manual `PATCH .../Settings {"Boot":{"BootOrder":["Boot0000"]}}` returning HTTP 200.
- **After:** the prefix match selects the correct boot option and sets it first; the host advances past `SetBootOrder`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
