### PR TITLE
fix: properly calculate boot order for dells

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -2608,13 +2608,36 @@ impl Bmc {
     }
 
     async fn get_boot_order(&self) -> Result<Vec<BootOption>, RedfishError> {
-        let boot_options = self.get_boot_options().await?;
-        let mut boot_order: Vec<BootOption> = Vec::new();
-        for boot_option in boot_options.members.iter() {
-            let id = boot_option.odata_id_get()?;
-            let boot_option = self.get_boot_option(id).await?;
-            boot_order.push(boot_option)
-        }
+        let system = self.s.get_system().await?;
+
+        let boot_options_id =
+            system
+                .boot
+                .boot_options
+                .clone()
+                .ok_or_else(|| RedfishError::MissingKey {
+                    key: "Boot.BootOptions".to_string(),
+                    url: system.odata.odata_id.clone(),
+                })?;
+
+        let all_boot_options = self
+            .s
+            .get_collection(boot_options_id)
+            .await?
+            .try_get::<BootOption>()?
+            .members;
+
+        let boot_order = system
+            .boot
+            .boot_order
+            .iter()
+            .filter_map(|reference| {
+                all_boot_options
+                    .iter()
+                    .find(|opt| opt.boot_option_reference == *reference)
+                    .cloned()
+            })
+            .collect();
 
         Ok(boot_order)
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -349,11 +349,6 @@ impl RedfishHttpClient {
         self.endpoint.user.is_none()
     }
 
-    /// Returns the hostname or IP address of the BMC this client targets.
-    pub fn host(&self) -> &str {
-        &self.endpoint.host
-    }
-
     pub async fn get<T>(&self, api: &str) -> Result<(StatusCode, T), RedfishError>
     where
         T: DeserializeOwned + ::std::fmt::Debug,


### PR DESCRIPTION
This PR fixes a bug where a Dell's boot order was calculated from the ordering in the `BootOptions` list rather than the `BootOrder`. It is not guaranteed that the order in the `BootOptions` is the same as the `BootOrder` as seen below:

```
        "BootOrder": [
            "Boot0001",
            "Boot0000",
            "Boot0002"
        ],
```

```
{
    "Members": [
        {
            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions/Boot0001"
        },
        {
            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions/Boot0002"
        },
        {
            "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions/Boot0000"
        }
    ],
    "Members@odata.count": 3,
    "Name": "Boot Options Collection",
    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions",
    "@odata.etag": "W/\"gen-1\"",
    "@odata.context": "/redfish/v1/$metadata#BootOptionCollection.BootOptionCollection",
    "@odata.type": "#BootOptionCollection.BootOptionCollection",
    "Description": "Collection of BootOptions"
}
```