### PR TITLE
feat: implement BMC reset to defaults for Supermicro

### DIFF
--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -862,7 +862,20 @@ impl Redfish for Bmc {
     }
 
     fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
+        Box::pin(async move {
+            // Supermicro uses an OEM action whose `Option` parameter selects one
+            // of three resets: `PreserveUser` keeps existing accounts,
+            // `ResetToADMIN` restores the legacy ADMIN/ADMIN credentials, and
+            // `ClearConfig` wipes the config and restores the unique factory
+            // password printed on the chassis label.
+            let url = format!(
+                "Managers/{}/Actions/Oem/SmcManagerConfig.Reset",
+                self.s.manager_id()
+            );
+            let mut arg = HashMap::new();
+            arg.insert("Option", "ClearConfig".to_string());
+            self.s.client.post(&url, arg).await.map(|_resp| ())
+        })
     }
 
     fn get_job_state<'a>(


### PR DESCRIPTION
### Summary

Fix `bmc_reset_to_defaults` for Supermicro BMCs. Supermicro doesn't accept the standard `Manager.ResetToDefaults` action (`ResetType: ResetAll`), which fails with a `PropertyValueFormatError` and breaks the decommissioning flow. Instead, this routes to the Supermicro OEM action `SmcManagerConfig.Reset` with `Option: "ClearConfig"`, which wipes the BMC config and restores the unique factory password printed on the chassis label (removing the site's secret password).

Fixes: https://github.com/NVIDIA/infra-controller/issues/2121

### Details

- Overrode `bmc_reset_to_defaults` in `src/supermicro.rs` to POST to `Managers/{id}/Actions/Oem/SmcManagerConfig.Reset`.
- `ClearConfig` chosen over the other OEM options: `PreserveUser` (keeps existing accounts) and `ResetToADMIN` (legacy ADMIN/ADMIN credentials).

### Tests

Ran `bmc-reset-to-defaults` against a Supermicro BMC and confirmed it succeeded. Also verified that the OEM redfish path exists on all SMCs currently in production.