### PR TITLE
fix(dell): Tolerate null values for TempRollupStatus on dell machines

### DIFF
--- a/src/model/oem/dell.rs
+++ b/src/model/oem/dell.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DefaultOnNull};
 
 use crate::model::BiosCommon;
 use crate::model::InvalidValueError;
@@ -90,6 +91,7 @@ pub struct SystemWrapper {
     pub dell_system: System,
 }
 
+#[serde_as]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct System {
@@ -116,7 +118,9 @@ pub struct System {
     pub populated_pcie_slots: i64,
     pub power_cap_enabled_state: Option<String>, // We see this field explicitly returned as null by Dell XE9680s
     pub system_generation: String,
-    pub temp_rollup_status: String,
+    #[serde(default)]
+    #[serde_as(deserialize_as = "DefaultOnNull")]
+    pub temp_rollup_status: String, // Observed as null if machine is off, kept as String for backwards-compat
     #[serde(rename = "UUID")]
     pub uuid: String,
     pub volt_rollup_status: String,

--- a/src/model/oem/dell.rs
+++ b/src/model/oem/dell.rs
@@ -116,7 +116,7 @@ pub struct System {
     pub populated_pcie_slots: i64,
     pub power_cap_enabled_state: Option<String>, // We see this field explicitly returned as null by Dell XE9680s
     pub system_generation: String,
-    pub temp_rollup_status: String,
+    pub temp_rollup_status: Option<String>, // Observed as null if machine is off
     #[serde(rename = "UUID")]
     pub uuid: String,
     pub volt_rollup_status: String,

--- a/src/model/system.rs
+++ b/src/model/system.rs
@@ -383,6 +383,18 @@ mod test {
     }
 
     #[test]
+    fn test_system_dell_null_temp_rollup() {
+        let data = include_str!("testdata/system_dell_null_temp_rollup.json");
+        let result: super::ComputerSystem = serde_json::from_str(data).unwrap();
+        let dell = result
+            .oem
+            .expect("should contain OEM data")
+            .dell
+            .expect("should contain dell-specific OEM data");
+        assert!(dell.dell_system.temp_rollup_status.is_empty());
+    }
+
+    #[test]
     fn test_system_bluefield_boot_valid() {
         // Old firmware versions of Bluefield deliver empty values for Boot fields
         // that are not valid enumeration values

--- a/src/model/system.rs
+++ b/src/model/system.rs
@@ -383,6 +383,18 @@ mod test {
     }
 
     #[test]
+    fn test_system_dell_null_temp_rollup() {
+        let data = include_str!("testdata/system_dell_null_temp_rollup.json");
+        let result: super::ComputerSystem = serde_json::from_str(data).unwrap();
+        let dell = result
+            .oem
+            .expect("should contain OEM data")
+            .dell
+            .expect("should contain dell-specific OEM data");
+        assert!(dell.dell_system.temp_rollup_status.is_none());
+    }
+
+    #[test]
     fn test_system_bluefield_boot_valid() {
         // Old firmware versions of Bluefield deliver empty values for Boot fields
         // that are not valid enumeration values

--- a/src/model/testdata/system_dell_null_temp_rollup.json
+++ b/src/model/testdata/system_dell_null_temp_rollup.json
@@ -1,0 +1,426 @@
+{
+  "@Redfish.Settings": {
+    "@odata.context": "/redfish/v1/$metadata#Settings.Settings",
+    "@odata.type": "#Settings.v1_4_0.Settings",
+    "SettingsObject": {
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Settings"
+    },
+    "SupportedApplyTimes": [
+      "OnReset"
+    ]
+  },
+  "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+  "@odata.type": "#ComputerSystem.v1_22_1.ComputerSystem",
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+      "ResetType@Redfish.AllowableValues": [
+        "On",
+        "ForceOff",
+        "ForceRestart",
+        "GracefulRestart",
+        "GracefulShutdown",
+        "PushPowerButton",
+        "Nmi",
+        "PowerCycle"
+      ]
+    }
+  },
+  "AssetTag": "",
+  "Bios": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+  },
+  "BiosVersion": "2.5.4",
+  "BootProgress": {
+    "LastState": "None"
+  },
+  "Boot": {
+    "BootOptions": {
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootOptions"
+    },
+    "Certificates": {
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Boot/Certificates"
+    },
+    "BootOrder": [
+      "Boot0002"
+    ],
+    "BootOrder@odata.count": 1,
+    "BootSourceOverrideEnabled": "Disabled",
+    "BootSourceOverrideMode": "UEFI",
+    "BootSourceOverrideTarget": "None",
+    "UefiTargetBootSourceOverride": null,
+    "BootSourceOverrideTarget@Redfish.AllowableValues": [
+      "None",
+      "Pxe",
+      "Floppy",
+      "Cd",
+      "Hdd",
+      "BiosSetup",
+      "Utilities",
+      "UefiTarget",
+      "SDCard",
+      "UefiHttp"
+    ],
+    "StopBootOnFault": "Never"
+  },
+  "Description": "Computer System which represents a machine (physical or virtual) and the local resources such as memory, cpu and other devices that can be accessed from that machine.",
+  "EthernetInterfaces": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/EthernetInterfaces"
+  },
+  "GraphicalConsole": {
+    "ConnectTypesSupported": [
+      "KVMIP"
+    ],
+    "ConnectTypesSupported@odata.count": 1,
+    "MaxConcurrentSessions": 6,
+    "ServiceEnabled": true
+  },
+  "HostName": "",
+  "HostWatchdogTimer": {
+    "FunctionEnabled": false,
+    "Status": {
+      "State": "Disabled"
+    },
+    "TimeoutAction": "None"
+  },
+  "HostingRoles": [],
+  "HostingRoles@odata.count": 0,
+  "Id": "System.Embedded.1",
+  "IndicatorLED": "Lit",
+  "IndicatorLED@Redfish.Deprecated": "Please migrate to use LocationIndicatorActive property",
+  "Links": {
+    "Chassis": [
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+      }
+    ],
+    "Chassis@odata.count": 1,
+    "CooledBy": [
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/0"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/1"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/2"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/3"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/4"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/5"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/6"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/7"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/8"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/9"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/10"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/11"
+      }
+    ],
+    "CooledBy@odata.count": 12,
+    "ManagedBy": [
+      {
+        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+      }
+    ],
+    "ManagedBy@odata.count": 1,
+    "Oem": {
+      "Dell": {
+        "@odata.type": "#DellOem.v1_3_0.DellOemLinks",
+        "BootOrder": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellBootSources"
+        },
+        "DellBootSources": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellBootSources"
+        },
+        "DellSoftwareInstallationService": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSoftwareInstallationService"
+        },
+        "DellVideoCollection": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellVideo"
+        },
+        "DellChassisCollection": {
+          "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Oem/Dell/DellChassis"
+        },
+        "DellPresenceAndStatusSensorCollection": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellPresenceAndStatusSensors"
+        },
+        "DellSensorCollection": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSensors"
+        },
+        "DellRollupStatusCollection": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRollupStatus"
+        },
+        "DellPSNumericSensorCollection": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellPSNumericSensors"
+        },
+        "DellVideoNetworkCollection": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellVideoNetwork"
+        },
+        "DellOSDeploymentService": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService"
+        },
+        "DellMetricService": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellMetricService"
+        },
+        "DellGPUSensorCollection": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellGPUSensors"
+        },
+        "DellRaidService": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService"
+        },
+        "DellNumericSensorCollection": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellNumericSensors"
+        },
+        "DellBIOSService": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellBIOSService"
+        },
+        "DellSlotCollection": {
+          "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSlots"
+        }
+      }
+    },
+    "PoweredBy": [
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power#/PowerSupplies/0"
+      },
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power#/PowerSupplies/1"
+      }
+    ],
+    "PoweredBy@odata.count": 2,
+    "TrustedComponents": [
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/TrustedComponents/TPM"
+      }
+    ],
+    "TrustedComponents@odata.count": 1
+  },
+  "LastResetTime": "0000-00-00T00:00:00+00:00",
+  "LocationIndicatorActive": false,
+  "Manufacturer": "Dell Inc.",
+  "Memory": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Memory"
+  },
+  "MemorySummary": {
+    "MemoryMirroring": "System",
+    "Status": {
+      "Health": "OK",
+      "HealthRollup": "OK",
+      "State": "Enabled"
+    },
+    "Status@Redfish.Deprecated": "Please migrate to use Status in the individual Memory resources",
+    "TotalSystemMemoryGiB": 256
+  },
+  "Model": "PowerEdge R760",
+  "Name": "System",
+  "NetworkInterfaces": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/NetworkInterfaces"
+  },
+  "Oem": {
+    "Dell": {
+      "@odata.type": "#DellOem.v1_3_0.DellOemResources",
+      "DellSystem": {
+        "BIOSReleaseDate": "01/16/2025",
+        "BaseBoardChassisSlot": "NA",
+        "BatteryRollupStatus": null,
+        "BladeGeometry": "NotApplicable",
+        "CMCIP": null,
+        "CMCRollupStatus": null,
+        "CPURollupStatus": "OK",
+        "ChassisModel": null,
+        "ChassisName": "Main System Chassis",
+        "ChassisServiceTag": "HR8FN34",
+        "ChassisSystemHeightUnit": 2,
+        "CoolingRollupStatus": "OK",
+        "CurrentRollupStatus": "OK",
+        "EstimatedExhaustTemperatureCelsius": 255,
+        "EstimatedSystemAirflowCFM": 255,
+        "ExpressServiceCode": "38652053152",
+        "FanRollupStatus": "OK",
+        "Id": "System.Embedded.1",
+        "IDSDMRedundancyStatus": null,
+        "IDSDMRollupStatus": null,
+        "IntrusionRollupStatus": "OK",
+        "IsOEMBranded": "False",
+        "LastSystemInventoryTime": "2026-06-26T20:19:52+00:00",
+        "LastUpdateTime": "2026-05-14T00:53:16+00:00",
+        "LicensingRollupStatus": "OK",
+        "ManagedSystemSize": "2 U",
+        "MaxCPUSockets": 2,
+        "MaxDIMMSlots": 32,
+        "MaxPCIeSlots": 8,
+        "MaxSystemMemoryMiB": 12582912,
+        "MemoryOperationMode": "OptimizerMode",
+        "Name": "DellSystem",
+        "NodeID": "HR8FN34",
+        "PSRollupStatus": "OK",
+        "PlatformGUID": "34334e4f-c0c8-4680-3810-00524c4c4544",
+        "PopulatedDIMMSlots": 8,
+        "PopulatedPCIeSlots": 1,
+        "PowerCapEnabledState": "Disabled",
+        "SDCardRollupStatus": null,
+        "SELRollupStatus": "OK",
+        "ServerAllocationWatts": null,
+        "StorageRollupStatus": "OK",
+        "SysMemErrorMethodology": "Multi-bitECC",
+        "SysMemFailOverState": "NotInUse",
+        "SysMemLocation": "SystemBoardOrMotherboard",
+        "SysMemPrimaryStatus": "OK",
+        "SystemGeneration": "16G Monolithic",
+        "SystemHealthRollupStatus": "OK",
+        "SystemID": 2667,
+        "SystemRevision": "I",
+        "TempRollupStatus": null,
+        "TempStatisticsRollupStatus": "OK",
+        "UUID": "4c4c4544-0052-3810-8046-c8c04f4e3334",
+        "VoltRollupStatus": "OK",
+        "smbiosGUID": "44454c4c-5200-1038-8046-c8c04f4e3334",
+        "@odata.context": "/redfish/v1/$metadata#DellSystem.DellSystem",
+        "@odata.type": "#DellSystem.v1_4_0.DellSystem",
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellSystem/System.Embedded.1"
+      }
+    }
+  },
+  "PCIeDevices": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/0-24"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/0-31"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/3-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/0-25"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/202-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/180-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/35-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/34-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/201-0"
+    }
+  ],
+  "PCIeDevices@odata.count": 9,
+  "PCIeFunctions": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/0-24/PCIeFunctions/0-24-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/0-31/PCIeFunctions/0-31-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/3-0/PCIeFunctions/3-0-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/0-31/PCIeFunctions/0-31-4"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/0-25/PCIeFunctions/0-25-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/202-0/PCIeFunctions/202-0-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/180-0/PCIeFunctions/180-0-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/180-0/PCIeFunctions/180-0-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/35-0/PCIeFunctions/35-0-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/34-0/PCIeFunctions/34-0-0"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/34-0/PCIeFunctions/34-0-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/35-0/PCIeFunctions/35-0-1"
+    },
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/PCIeDevices/201-0/PCIeFunctions/201-0-0"
+    }
+  ],
+  "PCIeFunctions@odata.count": 13,
+  "PartNumber": "0C9W19A03",
+  "PowerState": "Off",
+  "ProcessorSummary": {
+    "Count": 2,
+    "CoreCount": 48,
+    "LogicalProcessorCount": 96,
+    "Model": "Intel(R) Xeon(R) Gold 6442Y",
+    "Status": {
+      "Health": "OK",
+      "HealthRollup": "OK",
+      "State": "Enabled"
+    },
+    "Status@Redfish.Deprecated": "Please migrate to use Status in the individual Processor resources",
+    "ThreadingEnabled": true
+  },
+  "Processors": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Processors"
+  },
+  "SKU": "HR8FN34",
+  "SecureBoot": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SecureBoot"
+  },
+  "SerialNumber": "MXWSJ0045G015H",
+  "SimpleStorage": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/SimpleStorage"
+  },
+  "Status": {
+    "Health": "OK",
+    "HealthRollup": "OK",
+    "State": "Enabled"
+  },
+  "Storage": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage"
+  },
+  "SystemType": "Physical",
+  "TrustedModules": [
+    {
+      "FirmwareVersion": "7.2.3.1",
+      "InterfaceType": "TPM2_0",
+      "Status": {
+        "State": "Enabled"
+      }
+    }
+  ],
+  "TrustedModules@odata.count": 1,
+  "UUID": "4c4c4544-0052-3810-8046-c8c04f4e3334",
+  "VirtualMedia": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia"
+  },
+  "VirtualMediaConfig": {
+    "ServiceEnabled": true
+  }
+}


### PR DESCRIPTION
The Oem.Dell.DellSystem.TempRollupStatus value came back as `null` on a machine in our development environment when the host was off, causing a deserialization error. Update the field to be Option<String> to tolerate this. Use serde's DefaultOnNull to avoid a failure here.