### PR TITLE
feat: Support new vendor: VeraRubin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ mod nvidia_dpu;
 mod nvidia_gbswitch;
 mod nvidia_gbx00;
 mod nvidia_gh200;
+mod nvidia_vera_rubin;
 mod nvidia_viking;
 mod supermicro;
 pub use network::{Endpoint, RedfishClientPool, RedfishClientPoolBuilder, REDFISH_ENDPOINT};

--- a/src/model/service_root.rs
+++ b/src/model/service_root.rs
@@ -67,8 +67,9 @@ pub enum RedfishVendor {
     Supermicro,
     AMI, // Viking DGX H100
     Hpe,
-    NvidiaGH200,    // grace-hopper 200
+    NvidiaGH200, // grace-hopper 200
     NvidiaGBx00, // all Grace-Blackwell combinations 200, .. since openbmc fw and redfish schema are the same
+    VeraRubin,
     NvidiaGBSwitch, // GB NVLink switch
     P3809, // dummy for P3809, needs to be set to NvidiaGH200 or NvidiaGBSwitch based on chassis
     LiteOnPowerShelf,
@@ -108,6 +109,7 @@ impl ServiceRoot {
             }
             "nvidia" => match self.product.as_deref() {
                 Some("P3809") => RedfishVendor::P3809, // could be gh200 compute or nvswitch
+                Some("VR NVL72") => RedfishVendor::VeraRubin,
                 Some("GB200 NVL") | Some("GB BMC") => RedfishVendor::NvidiaGBx00,
                 _ => RedfishVendor::NvidiaDpu,
             },
@@ -117,6 +119,11 @@ impl ServiceRoot {
             "delta" => RedfishVendor::DeltaPowerShelf,
             _ => RedfishVendor::Unknown,
         })
+    }
+
+    /// Vera Rubin compute-tray host BMC.
+    pub fn is_vera_rubin(&self) -> bool {
+        self.vendor() == Some(RedfishVendor::VeraRubin)
     }
 
     /// Check if this system has an AMI-based BMC (indicated by "Ami" key in OEM field)
@@ -157,5 +164,16 @@ mod test {
             ..Default::default()
         };
         assert_eq!(result.vendor().unwrap(), RedfishVendor::NvidiaDpu);
+    }
+
+    #[test]
+    fn test_nvidia_vera_rubin_service_root() {
+        let result = ServiceRoot {
+            vendor: Some("NVIDIA".to_string()),
+            product: Some("VR NVL72".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::VeraRubin);
+        assert!(result.is_vera_rubin());
     }
 }

--- a/src/model/testdata/thermal-nvidia-vr-thermalmetrics.json
+++ b/src/model/testdata/thermal-nvidia-vr-thermalmetrics.json
@@ -1,0 +1,13 @@
+{
+    "@odata.id": "/redfish/v1/Chassis/BMC_0/ThermalSubsystem/ThermalMetrics",
+    "@odata.type": "#ThermalMetrics.v1_0_1.ThermalMetrics",
+    "Id": "ThermalMetrics",
+    "Name": "Chassis Thermal Metrics",
+    "TemperatureReadingsCelsius": [
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/BMC_0/Sensors/BMC_0_Temp_0",
+            "DeviceName": "BMC_0_Temp_0",
+            "Reading": 56.062
+        }
+    ]
+}

--- a/src/model/thermal.rs
+++ b/src/model/thermal.rs
@@ -70,11 +70,14 @@ pub struct Fan {
     pub thresholds: Option<FanThresholds>,
 }
 
+/// One `TemperatureReadingsCelsius` entry on NVIDIA OpenBMC host BMCs.
+/// GB200 includes `@odata.id`; Vera Rubin may omit it and only provide `DataSourceUri`.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct TemperatureOemNvidia {
-    #[serde(rename = "@odata.id")]
-    pub odata_id: String,
+    #[serde(rename = "@odata.id", default)]
+    pub odata_id: Option<String>,
+    pub data_source_uri: Option<String>,
     pub device_name: Option<String>,
     pub physical_context: Option<String>,
     pub reading: Option<f64>,
@@ -137,13 +140,24 @@ impl Default for Temperature {
 
 impl From<TemperatureOemNvidia> for Temperature {
     fn from(temp: TemperatureOemNvidia) -> Self {
+        let name = temp
+            .device_name
+            .or_else(|| sensor_name_from_uri(temp.data_source_uri.as_deref()))
+            .or_else(|| sensor_name_from_uri(temp.odata_id.as_deref()))
+            .unwrap_or_else(|| "Unknown".to_string());
         Self {
-            name: temp.device_name.unwrap_or("Unknown".to_string()),
+            name,
             reading_celsius: temp.reading,
             physical_context: temp.physical_context,
             ..Default::default()
         }
     }
+}
+
+fn sensor_name_from_uri(uri: Option<&str>) -> Option<String> {
+    uri.and_then(|uri| uri.rsplit('/').next())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
 }
 
 impl From<Sensor> for Temperature {
@@ -300,6 +314,41 @@ impl StatusVec for Thermal {
 
 #[cfg(test)]
 mod test {
+    use super::{Temperature, TemperatureOemNvidia, TemperaturesOemNvidia};
+
+    #[test]
+    fn test_temperature_oem_nvidia_vera_rubin_without_odata_id() {
+        let body = include_str!("testdata/thermal-nvidia-vr-thermalmetrics.json");
+        let metrics: TemperaturesOemNvidia = serde_json::from_str(body).unwrap();
+        let readings = metrics.temperature_readings_celsius.unwrap();
+        assert_eq!(readings.len(), 1);
+        assert!(readings[0].odata_id.is_none());
+        assert_eq!(
+            readings[0].data_source_uri.as_deref(),
+            Some("/redfish/v1/Chassis/BMC_0/Sensors/BMC_0_Temp_0")
+        );
+
+        let temp: Temperature = readings[0].clone().into();
+        assert_eq!(temp.name, "BMC_0_Temp_0");
+        assert_eq!(temp.reading_celsius, Some(56.062));
+    }
+
+    #[test]
+    fn test_temperature_oem_nvidia_gb200_with_odata_id() {
+        let reading: TemperatureOemNvidia = serde_json::from_str(
+            r#"{
+                "@odata.id": "/redfish/v1/Chassis/BMC_0/Sensors/BMC_0_DCSCM_Temp_0",
+                "DataSourceUri": "/redfish/v1/Chassis/BMC_0/Sensors/BMC_0_DCSCM_Temp_0",
+                "DeviceName": "BMC_0_DCSCM_Temp_0",
+                "Reading": 33.875
+            }"#,
+        )
+        .unwrap();
+        let temp: Temperature = reading.into();
+        assert_eq!(temp.name, "BMC_0_DCSCM_Temp_0");
+        assert_eq!(temp.reading_celsius, Some(33.875));
+    }
+
     #[test]
     fn test_thermal_parser() {
         // TODO: hpe test data is obsolete, needs to be updated from latest iLO BMC

--- a/src/nvidia_vera_rubin.rs
+++ b/src/nvidia_vera_rubin.rs
@@ -1,0 +1,1626 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+use crate::{Chassis, EnabledDisabled, REDFISH_ENDPOINT};
+use regex::Regex;
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+use std::sync::OnceLock;
+use std::{collections::HashMap, path::Path, time::Duration};
+use tokio::fs::File;
+
+use crate::model::account_service::ManagerAccount;
+use crate::model::certificate::Certificate;
+use crate::model::component_integrity::{ComponentIntegrities, RegexToFirmwareIdOptions};
+use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
+use crate::model::sensor::{GPUSensors, Sensor, Sensors};
+use crate::model::service_root::RedfishVendor;
+use crate::model::storage::DriveCollection;
+use crate::model::task::Task;
+use crate::model::thermal::Fan;
+use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
+use crate::{
+    jsonmap,
+    model::{
+        boot::{BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
+        chassis::{Assembly, NetworkAdapter},
+        power::{Power, PowerSupply, Voltages},
+        sel::{LogEntry, LogEntryCollection},
+        service_root::ServiceRoot,
+        storage::Drives,
+        thermal::{LeakDetector, Temperature, TemperaturesOemNvidia, Thermal},
+        BootOption, ComputerSystem, Manager,
+    },
+    standard::RedfishStandard,
+    BiosProfileType, Collection, NetworkDeviceFunction, ODataId, Redfish, RedfishError, Resource,
+};
+use crate::{JobState, MachineSetupDiff, MachineSetupStatus, RoleId};
+
+const UEFI_PASSWORD_NAME: &str = "AdminPassword";
+
+pub struct Bmc {
+    s: RedfishStandard,
+}
+
+impl Bmc {
+    pub fn new(s: RedfishStandard) -> Result<Bmc, RedfishError> {
+        Ok(Bmc { s })
+    }
+}
+
+#[derive(Copy, Clone)]
+pub enum BootOptionName {
+    Http,
+    Pxe,
+    Hdd,
+}
+
+impl BootOptionName {
+    fn to_string(self) -> &'static str {
+        match self {
+            BootOptionName::Http => "UEFI HTTPv4",
+            BootOptionName::Pxe => "UEFI PXEv4",
+            BootOptionName::Hdd => "HD(",
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
+enum BootOptionMatchField {
+    DisplayName,
+    UefiDevicePath,
+}
+
+impl BootOptionMatchField {
+    #[allow(dead_code)]
+    fn to_string(self) -> &'static str {
+        match self {
+            BootOptionMatchField::DisplayName => "Display Name",
+            BootOptionMatchField::UefiDevicePath => "Uefi Device Path",
+        }
+    }
+}
+
+impl Display for BootOptionMatchField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Debug::fmt(&self, f)
+    }
+}
+
+// Supported component to firmware mapping.
+// GPU, Source: HGX_IRoT_GPU_X Target: HGX_FW_GPU_X
+fn get_component_integrity_id_to_firmware_inventory_id_options(
+) -> Result<&'static Vec<RegexToFirmwareIdOptions>, RedfishError> {
+    static RE: OnceLock<Result<Vec<RegexToFirmwareIdOptions>, String>> = OnceLock::new();
+    RE.get_or_init(|| {
+        Ok(vec![RegexToFirmwareIdOptions {
+            id_prefix: "HGX_FW_",
+            // Assuming our static pattern is good, this is probably
+            // safe, but still check for an error instead of unwrapping.
+            pattern: Regex::new(r"HGX_IRoT_(GPU_\d+)").map_err(|e| e.to_string())?,
+        }])
+    })
+    .as_ref()
+    .map_err(|e| RedfishError::GenericError {
+        error: format!("Failed to compile regex: {}", e),
+    })
+}
+impl Redfish for Bmc {
+    fn create_user<'a>(
+        &'a self,
+        username: &'a str,
+        password: &'a str,
+        role_id: RoleId,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    }
+
+    fn delete_user<'a>(
+        &'a self,
+        username: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.delete_user(username).await })
+    }
+
+    fn change_username<'a>(
+        &'a self,
+        old_name: &'a str,
+        new_name: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.change_username(old_name, new_name).await })
+    }
+
+    fn change_password<'a>(
+        &'a self,
+        user: &'a str,
+        new: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.change_password(user, new).await })
+    }
+
+    fn change_password_by_id<'a>(
+        &'a self,
+        account_id: &'a str,
+        new_pass: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
+    }
+
+    fn get_accounts<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
+        Box::pin(async move { self.s.get_accounts().await })
+    }
+
+    fn get_firmware<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> crate::RedfishFuture<
+        'a,
+        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
+    > {
+        Box::pin(async move {
+            let mut inv = self.s.get_firmware(id).await?;
+            // BMC firmware gets prepended with "GB200Nvl-", (L, not 1!) so trim that off when we see it.
+            inv.version = inv.version.map(|x| {
+                x.strip_prefix("GB200Nvl-")
+                    .unwrap_or(x.as_str())
+                    .to_string()
+            });
+            Ok(inv)
+        })
+    }
+
+    fn get_software_inventories<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_software_inventories().await })
+    }
+
+    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_tasks().await })
+    }
+
+    fn get_task<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
+        Box::pin(async move { self.s.get_task(id).await })
+    }
+
+    fn get_power_state<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<crate::PowerState, RedfishError>> {
+        Box::pin(async move { self.s.get_power_state().await })
+    }
+
+    fn get_power_metrics<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<crate::Power, RedfishError>> {
+        Box::pin(async move {
+            let mut voltages = Vec::new();
+            let mut power_supplies = Vec::new();
+            // gb200 bianca has empty PowerSupplies on several chassis items
+            // for now assemble power supply details from PDB_0 chassis entries
+            let mut url = "Chassis/PDB_0".to_string();
+            let (_status_code, pdb): (StatusCode, PowerSupply) = self.s.client.get(&url).await?;
+            let mut hsc0 = pdb.clone();
+            let mut hsc1 = pdb.clone();
+            // voltage sensors are on several chassis items under sensors
+            let chassis_all = self.s.get_chassis_all().await?;
+            for chassis_id in chassis_all {
+                url = format!("Chassis/{}", chassis_id);
+                let (_status_code, chassis): (StatusCode, Chassis) =
+                    self.s.client.get(&url).await?;
+                if chassis.sensors.is_none() {
+                    continue;
+                }
+                // walk through all Chassis/*/Sensors/ for voltage and PDB_0 for power supply details
+                url = format!("Chassis/{}/Sensors", chassis_id);
+                let (_status_code, sensors): (StatusCode, Sensors) =
+                    self.s.client.get(&url).await?;
+                for sensor in sensors.members {
+                    if chassis_id == *"PDB_0" {
+                        // get amps and watts for power supply
+                        if sensor.odata_id.contains("HSC_0_Pwr") {
+                            url = sensor
+                                .odata_id
+                                .replace(&format!("/{REDFISH_ENDPOINT}/"), "");
+                            let (_status_code, t): (StatusCode, Sensor) =
+                                self.s.client.get(&url).await?;
+                            hsc0.last_power_output_watts = t.reading;
+                            hsc0.power_output_watts = t.reading;
+                            hsc0.power_capacity_watts = t.reading_range_max;
+                        }
+                        if sensor.odata_id.contains("HSC_0_Cur") {
+                            url = sensor
+                                .odata_id
+                                .replace(&format!("/{REDFISH_ENDPOINT}/"), "");
+                            let (_status_code, t): (StatusCode, Sensor) =
+                                self.s.client.get(&url).await?;
+                            hsc0.power_output_amps = t.reading;
+                        }
+                        if sensor.odata_id.contains("HSC_1_Pwr") {
+                            url = sensor
+                                .odata_id
+                                .replace(&format!("/{REDFISH_ENDPOINT}/"), "");
+                            let (_status_code, t): (StatusCode, Sensor) =
+                                self.s.client.get(&url).await?;
+                            hsc1.last_power_output_watts = t.reading;
+                            hsc1.power_output_watts = t.reading;
+                            hsc1.power_capacity_watts = t.reading_range_max;
+                        }
+                        if sensor.odata_id.contains("HSC_1_Cur") {
+                            url = sensor
+                                .odata_id
+                                .replace(&format!("/{REDFISH_ENDPOINT}/"), "");
+                            let (_status_code, t): (StatusCode, Sensor) =
+                                self.s.client.get(&url).await?;
+                            hsc1.power_output_amps = t.reading;
+                        }
+                    }
+                    // now all voltage sensors in all chassis
+                    if !sensor.odata_id.contains("Volt") {
+                        continue;
+                    }
+                    url = sensor
+                        .odata_id
+                        .replace(&format!("/{REDFISH_ENDPOINT}/"), "");
+                    let (_status_code, t): (StatusCode, Sensor) = self.s.client.get(&url).await?;
+                    let sensor: Voltages = Voltages::from(t);
+                    voltages.push(sensor);
+                }
+            }
+
+            power_supplies.push(hsc0);
+            power_supplies.push(hsc1);
+            let power = Power {
+                odata: None,
+                id: "Power".to_string(),
+                name: "Power".to_string(),
+                power_control: vec![],
+                power_supplies: Some(power_supplies),
+                voltages: Some(voltages),
+                redundancy: None,
+            };
+            Ok(power)
+        })
+    }
+
+    fn power<'a>(
+        &'a self,
+        action: crate::SystemPowerControl,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            if action == crate::SystemPowerControl::ACPowercycle {
+                let args: HashMap<String, String> =
+                    HashMap::from([("ResetType".to_string(), "AuxPowerCycle".to_string())]);
+                return self
+                    .s
+                    .client
+                    .post(
+                        "Chassis/BMC_0/Actions/Oem/NvidiaChassis.AuxPowerReset",
+                        args,
+                    )
+                    .await
+                    .map(|_status_code| ());
+            }
+
+            self.s.power(action).await
+        })
+    }
+
+    fn ac_powercycle_supported_by_power(&self) -> bool {
+        true
+    }
+
+    fn bmc_reset<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.bmc_reset().await })
+    }
+
+    fn chassis_reset<'a>(
+        &'a self,
+        chassis_id: &'a str,
+        reset_type: crate::SystemPowerControl,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
+    }
+
+    fn get_thermal_metrics<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<crate::Thermal, RedfishError>> {
+        Box::pin(async move {
+            let mut temperatures = Vec::new();
+            let mut fans = Vec::new();
+            let mut leak_detectors = Vec::new();
+
+            // gb200 bianca has temperature sensors in several chassis items
+            let chassis_all = self.s.get_chassis_all().await?;
+            for chassis_id in chassis_all {
+                let mut url = format!("Chassis/{}", chassis_id);
+                let (_status_code, chassis): (StatusCode, Chassis) =
+                    self.s.client.get(&url).await?;
+                if chassis.thermal_subsystem.is_some() {
+                    url = format!("Chassis/{}/ThermalSubsystem/ThermalMetrics", chassis_id);
+                    let (_status_code, temps): (StatusCode, TemperaturesOemNvidia) =
+                        self.s.client.get(&url).await?;
+                    if let Some(temp) = temps.temperature_readings_celsius {
+                        for t in temp {
+                            let sensor: Temperature = Temperature::from(t);
+                            temperatures.push(sensor);
+                        }
+                    }
+                    // currently the gb200 bianca board we have uses liquid cooling
+                    // walk through leak detection sensors and add those
+                    url = format!(
+                        "Chassis/{}/ThermalSubsystem/LeakDetection/LeakDetectors",
+                        chassis_id
+                    );
+
+                    let res: Result<(StatusCode, Sensors), RedfishError> =
+                        self.s.client.get(&url).await;
+
+                    if let Ok((_, sensors)) = res {
+                        for sensor in sensors.members {
+                            url = sensor
+                                .odata_id
+                                .replace(&format!("/{REDFISH_ENDPOINT}/"), "");
+                            let (_status_code, l): (StatusCode, LeakDetector) =
+                                self.s.client.get(&url).await?;
+                            leak_detectors.push(l);
+                        }
+                    }
+                }
+                if chassis.sensors.is_some() {
+                    // Special handling for GB200s that may not have all their drives installed but still have sensors
+                    if let Some(backplane_num) = chassis_id.strip_prefix("StorageBackplane_") {
+                        url = format!("Chassis/{}/Drives", chassis_id);
+
+                        // Fetch drives and find their respective sensor
+                        if let Ok((_status_code, drives)) =
+                            self.s.client.get::<DriveCollection>(&url).await
+                        {
+                            for sensor in drives
+                                .members
+                                .iter()
+                                .filter_map(|drive| {
+                                    // Extract drive slot ID: "/path/NVMe_SSD_200" -> "200" -> 200
+                                    let drive_id = drive
+                                        .odata_id
+                                        .split('/')
+                                        .next_back()?
+                                        .split('_')
+                                        .next_back()?
+                                        .parse::<u32>()
+                                        .ok()?;
+
+                                    Some((drive_id % 4, backplane_num))
+                                })
+                                .map(|(sensor_index, backplane)| {
+                                    format!(
+                                        "Chassis/{}/Sensors/StorageBackplane_{}_SSD_{}_Temp_0",
+                                        chassis_id, backplane, sensor_index
+                                    )
+                                })
+                            {
+                                // Fetch sensor and add to temperatures if successful
+                                if let Ok((_status_code, sensor_data)) =
+                                    self.s.client.get::<Sensor>(&sensor).await
+                                {
+                                    temperatures.push(Temperature::from(sensor_data));
+                                }
+                            }
+                        }
+                    } else {
+                        // walk through Chassis/*/Sensors/*/*Temp*/
+                        url = format!("Chassis/{}/Sensors", chassis_id);
+                        let (_status_code, sensors): (StatusCode, Sensors) =
+                            self.s.client.get(&url).await?;
+                        for sensor in sensors.members {
+                            if !sensor.odata_id.contains("Temp") {
+                                continue;
+                            }
+                            url = sensor
+                                .odata_id
+                                .replace(&format!("/{REDFISH_ENDPOINT}/"), "");
+                            let (_status_code, t): (StatusCode, Sensor) =
+                                self.s.client.get(&url).await?;
+                            let sensor: Temperature = Temperature::from(t);
+                            temperatures.push(sensor);
+                        }
+                    }
+                }
+
+                // gb200 has fans under chassis sensors instead of thermal like other vendors, look for them in Chassis_0
+                if chassis_id == *"Chassis_0" {
+                    url = format!("Chassis/{}/Sensors", chassis_id);
+                    let (_status_code, sensors): (StatusCode, Sensors) =
+                        self.s.client.get(&url).await?;
+                    for sensor in sensors.members {
+                        if sensor.odata_id.contains("FAN") {
+                            url = sensor
+                                .odata_id
+                                .replace(&format!("/{REDFISH_ENDPOINT}/"), "");
+                            let (_status_code, fan): (StatusCode, Fan) =
+                                self.s.client.get(&url).await?;
+                            fans.push(fan);
+                        }
+                    }
+                }
+            }
+            let thermals = Thermal {
+                temperatures,
+                fans,
+                leak_detectors: Some(leak_detectors),
+                ..Default::default()
+            };
+            Ok(thermals)
+        })
+    }
+
+    fn get_gpu_sensors<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<GPUSensors>, RedfishError>> {
+        Box::pin(async move {
+            Err(RedfishError::NotSupported(
+                "GB200 has no sensors under Chassis/HGX_GPU_#/Sensors/".to_string(),
+            ))
+        })
+    }
+
+    fn get_system_event_log<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
+        Box::pin(async move { self.get_system_event_log().await })
+    }
+
+    fn get_bmc_event_log<'a>(
+        &'a self,
+        from: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
+        Box::pin(async move { self.s.get_bmc_event_log(from).await })
+    }
+
+    fn get_drives_metrics<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
+        Box::pin(async move { self.s.get_drives_metrics().await })
+    }
+
+    fn machine_setup<'a>(
+        &'a self,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
+        _bios_profiles: &'a HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
+        _selected_profile: BiosProfileType,
+        _oem_manager_profiles: &'a HashMap<
+            RedfishVendor,
+            HashMap<String, HashMap<BiosProfileType, HashMap<String, serde_json::Value>>>,
+        >,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            self.disable_secure_boot().await?;
+
+            let bios_attrs = self.machine_setup_attrs().await?;
+            let mut attrs = HashMap::new();
+            attrs.extend(bios_attrs);
+            let body = HashMap::from([("Attributes", attrs)]);
+            let url = format!("Systems/{}/Bios/Settings", self.s.system_id());
+            self.s
+                .client
+                .patch(&url, body)
+                .await
+                .map(|_status_code| None)
+        })
+    }
+
+    fn machine_setup_status<'a>(
+        &'a self,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
+    ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
+        Box::pin(async move {
+            // Resolve `InterfaceId` to a MAC via the Redfish-standard
+            // EthernetInterface resource.
+            let resolved_mac = match boot_interface {
+                Some(b) => Some(crate::resolve_boot_interface_mac(self, b).await?),
+                None => None,
+            };
+            let boot_interface_mac = resolved_mac.as_deref();
+
+            // Check BIOS and BMC attributes
+            let mut diffs = self.diff_bios_bmc_attr().await?;
+
+            // Check the first boot option
+            if let Some(mac) = boot_interface_mac {
+                let (expected, actual) =
+                    self.get_expected_and_actual_first_boot_option(mac).await?;
+                if expected.is_none() || expected != actual {
+                    diffs.push(MachineSetupDiff {
+                        key: "boot_first".to_string(),
+                        expected: expected.unwrap_or_else(|| "Not found".to_string()),
+                        actual: actual.unwrap_or_else(|| "Not found".to_string()),
+                    });
+                }
+            }
+
+            // We don't lockdown on Vera Rubin, so we don't need to check for it
+
+            Ok(MachineSetupStatus {
+                is_done: diffs.is_empty(),
+                diffs,
+            })
+        })
+    }
+
+    fn set_machine_password_policy<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            use serde_json::Value::Number;
+            // These are also the defaults
+            let body = HashMap::from([
+                /* we were able to set AccountLockoutThreshold on the initial 3 GB200 trays we received
+                   however, with the recent trays we received, it is not happy with setting a value of 0
+                   for AccountLockoutThreshold: "The property 'AccountLockoutThreshold' with the requested value
+                   of '0' could not be written because the value does not meet the constraints of the implementation."
+                   Never lock
+                  ("AccountLockoutThreshold", Number(0.into())),
+
+                  instead, use the same threshold that we picked for vikings: the bmc will lock the account out after 4 attempts
+                */
+                ("AccountLockoutThreshold", Number(4.into())),
+                // 600 is the smallest value it will accept. 10 minutes, in seconds.
+                ("AccountLockoutDuration", Number(600.into())),
+            ]);
+            self.s
+                .client
+                .patch("AccountService", body)
+                .await
+                .map(|_status_code| ())
+        })
+    }
+
+    fn lockdown<'a>(
+        &'a self,
+        _target: crate::EnabledDisabled,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            // OpenBMC does not provide a lockdown
+            Ok(())
+        })
+    }
+
+    fn lockdown_status<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
+        Box::pin(async move { self.s.lockdown_status().await })
+    }
+
+    fn setup_serial_console<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.setup_serial_console().await })
+    }
+
+    fn serial_console_status<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
+        Box::pin(async move { self.s.serial_console_status().await })
+    }
+
+    fn get_boot_options<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<crate::BootOptions, RedfishError>> {
+        Box::pin(async move { self.s.get_boot_options().await })
+    }
+
+    fn get_boot_option<'a>(
+        &'a self,
+        option_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
+        Box::pin(async move { self.s.get_boot_option(option_id).await })
+    }
+
+    fn boot_once<'a>(
+        &'a self,
+        target: crate::Boot,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            let override_target = match target {
+                crate::Boot::Pxe => BootSourceOverrideTarget::Pxe,
+                crate::Boot::HardDisk => BootSourceOverrideTarget::Hdd,
+                crate::Boot::UefiHttp => BootSourceOverrideTarget::UefiHttp,
+            };
+            Redfish::set_boot_override(
+                self,
+                BootOverride {
+                    target: override_target,
+                    enabled: BootSourceOverrideEnabled::Once,
+                    mode: None,
+                    http_boot_uri: None,
+                },
+            )
+            .await?;
+            Ok(())
+        })
+    }
+
+    fn boot_first<'a>(
+        &'a self,
+        target: crate::Boot,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            match target {
+                crate::Boot::Pxe => self.set_boot_order(BootOptionName::Pxe).await,
+                crate::Boot::HardDisk => {
+                    // We're looking for a UefiDevicePath like this:
+                    // HD(1,GPT,A04D0F1E-E02F-4725-9434-0699B52D8FF2,0x800,0x100000)/\\EFI\\ubuntu\\shimaa64.efi
+                    // The DisplayName will be something like "ubuntu".
+                    let boot_array = self
+                        .get_boot_options_ids_with_first(
+                            BootOptionName::Hdd,
+                            BootOptionMatchField::UefiDevicePath,
+                            None,
+                        )
+                        .await?;
+                    self.change_boot_order(boot_array).await
+                }
+                crate::Boot::UefiHttp => self.set_boot_order(BootOptionName::Http).await,
+            }
+        })
+    }
+
+    fn set_boot_override<'a>(
+        &'a self,
+        settings: BootOverride,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            let mut boot_data: HashMap<String, serde_json::Value> = HashMap::new();
+            boot_data.insert(
+                "BootSourceOverrideTarget".to_string(),
+                settings.target.to_string().into(),
+            );
+            boot_data.insert(
+                "BootSourceOverrideEnabled".to_string(),
+                settings.enabled.to_string().into(),
+            );
+            if let Some(mode) = settings.mode {
+                boot_data.insert(
+                    "BootSourceOverrideMode".to_string(),
+                    mode.to_string().into(),
+                );
+            }
+            if let Some(uri) = settings.http_boot_uri {
+                boot_data.insert("HttpBootUri".to_string(), uri.into());
+            }
+            let url = format!("Systems/{}/Settings", self.s.system_id());
+            self.s
+                .client
+                .patch(&url, HashMap::from([("Boot", boot_data)]))
+                .await?;
+            Ok(None)
+        })
+    }
+
+    fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.clear_tpm().await })
+    }
+
+    fn pcie_devices<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<crate::PCIeDevice>, RedfishError>> {
+        Box::pin(async move { self.s.pcie_devices().await })
+    }
+
+    fn update_firmware<'a>(
+        &'a self,
+        firmware: tokio::fs::File,
+    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
+        Box::pin(async move { self.s.update_firmware(firmware).await })
+    }
+
+    fn get_update_service<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
+        Box::pin(async move { self.s.get_update_service().await })
+    }
+
+    fn update_firmware_multipart<'a>(
+        &'a self,
+        filename: &'a Path,
+        _reboot: bool,
+        timeout: Duration,
+        component_type: ComponentType,
+    ) -> crate::RedfishFuture<'a, Result<String, RedfishError>> {
+        Box::pin(async move {
+            let firmware = File::open(&filename)
+                .await
+                .map_err(|e| RedfishError::FileError(format!("Could not open file: {}", e)))?;
+
+            let update_service = self.s.get_update_service().await?;
+
+            if update_service.multipart_http_push_uri.is_empty() {
+                return Err(RedfishError::NotSupported(
+                    "Host BMC does not support HTTP multipart push".to_string(),
+                ));
+            }
+
+            let parameters = serde_json::to_string(&UpdateParameters::new(component_type))
+                .map_err(|e| RedfishError::JsonSerializeError {
+                    url: "".to_string(),
+                    object_debug: "".to_string(),
+                    source: e,
+                })?;
+
+            let (_status_code, _loc, body) = self
+                .s
+                .client
+                .req_update_firmware_multipart(
+                    filename,
+                    firmware,
+                    parameters,
+                    &update_service.multipart_http_push_uri,
+                    true,
+                    timeout,
+                )
+                .await?;
+
+            let task: Task =
+                serde_json::from_str(&body).map_err(|e| RedfishError::JsonDeserializeError {
+                    url: update_service.multipart_http_push_uri,
+                    body,
+                    source: e,
+                })?;
+
+            Ok(task.id)
+        })
+    }
+
+    fn bios<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<
+        'a,
+        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
+    > {
+        Box::pin(async move { self.s.bios().await })
+    }
+
+    fn set_bios<'a>(
+        &'a self,
+        values: HashMap<String, serde_json::Value>,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_bios(values).await })
+    }
+
+    fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.reset_bios().await })
+    }
+
+    fn pending<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<
+        'a,
+        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
+    > {
+        Box::pin(async move { self.s.pending().await })
+    }
+
+    fn clear_pending<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.clear_pending().await })
+    }
+
+    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
+        Box::pin(async move { self.s.get_system().await })
+    }
+
+    fn get_secure_boot<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<crate::model::secure_boot::SecureBoot, RedfishError>> {
+        Box::pin(async move { self.s.get_secure_boot().await })
+    }
+
+    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.enable_secure_boot().await })
+    }
+
+    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.disable_secure_boot().await })
+    }
+
+    fn get_secure_boot_certificate<'a>(
+        &'a self,
+        database_id: &'a str,
+        certificate_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_secure_boot_certificate(database_id, certificate_id)
+                .await
+        })
+    }
+
+    fn get_secure_boot_certificates<'a>(
+        &'a self,
+        database_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
+    }
+
+    fn add_secure_boot_certificate<'a>(
+        &'a self,
+        pem_cert: &'a str,
+        database_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .add_secure_boot_certificate(pem_cert, database_id)
+                .await
+        })
+    }
+
+    fn get_chassis_all<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_chassis_all().await })
+    }
+
+    fn get_chassis<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<crate::Chassis, RedfishError>> {
+        Box::pin(async move { self.s.get_chassis(id).await })
+    }
+
+    fn get_chassis_assembly<'a>(
+        &'a self,
+        chassis_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
+        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
+    }
+
+    fn get_chassis_network_adapters<'a>(
+        &'a self,
+        chassis_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_chassis_network_adapters(chassis_id).await })
+    }
+
+    fn get_chassis_network_adapter<'a>(
+        &'a self,
+        chassis_id: &'a str,
+        id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
+        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
+    }
+
+    fn get_base_network_adapters<'a>(
+        &'a self,
+        system_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
+    }
+
+    fn get_base_network_adapter<'a>(
+        &'a self,
+        system_id: &'a str,
+        id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
+        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
+    }
+
+    fn get_manager_ethernet_interfaces<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
+    }
+
+    fn get_manager_ethernet_interface<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
+        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
+    }
+
+    fn get_system_ethernet_interfaces<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { Ok(vec![]) })
+    }
+
+    fn get_system_ethernet_interface<'a>(
+        &'a self,
+        id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
+        Box::pin(async move {
+            Err(RedfishError::NotSupported(format!(
+                "GB200 doesn't have Systems EthernetInterface {id}"
+            )))
+        })
+    }
+
+    fn get_ports<'a>(
+        &'a self,
+        chassis_id: &'a str,
+        network_adapter: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move {
+            let url = format!(
+                "Chassis/{}/NetworkAdapters/{}/Ports",
+                chassis_id, network_adapter
+            );
+            self.s.get_members(&url).await
+        })
+    }
+
+    fn get_port<'a>(
+        &'a self,
+        chassis_id: &'a str,
+        network_adapter: &'a str,
+        id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<crate::NetworkPort, RedfishError>> {
+        Box::pin(async move {
+            let url = format!(
+                "Chassis/{}/NetworkAdapters/{}/Ports/{}",
+                chassis_id, network_adapter, id
+            );
+            let (_status_code, body) = self.s.client.get(&url).await?;
+            Ok(body)
+        })
+    }
+
+    fn get_network_device_function<'a>(
+        &'a self,
+        _chassis_id: &'a str,
+        _id: &'a str,
+        _port: Option<&'a str>,
+    ) -> crate::RedfishFuture<'a, Result<NetworkDeviceFunction, RedfishError>> {
+        Box::pin(async move {
+            Err(RedfishError::NotSupported(
+                "GB200 doesn't have Device Functions in NetworkAdapters yet".to_string(),
+            ))
+        })
+    }
+
+    /// http://redfish.dmtf.org/schemas/v1/NetworkDeviceFunctionCollection.json
+    fn get_network_device_functions<'a>(
+        &'a self,
+        _chassis_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move {
+            Err(RedfishError::NotSupported(
+                "GB200 doesn't have Device Functions in NetworkAdapters yet".to_string(),
+            ))
+        })
+    }
+
+    // Set current_uefi_password to "" if there isn't one yet. By default there isn't a password.
+    /// Set new_uefi_password to "" to disable it.
+    fn change_uefi_password<'a>(
+        &'a self,
+        current_uefi_password: &'a str,
+        new_uefi_password: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .change_bios_password(UEFI_PASSWORD_NAME, current_uefi_password, new_uefi_password)
+                .await
+        })
+    }
+
+    fn change_boot_order<'a>(
+        &'a self,
+        boot_array: Vec<String>,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            let body = HashMap::from([("Boot", HashMap::from([("BootOrder", boot_array)]))]);
+            let url = format!("Systems/{}/Settings", self.s.system_id());
+            self.s.client.patch(&url, body).await?;
+            Ok(())
+        })
+    }
+
+    fn get_service_root<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
+        Box::pin(async move { self.s.get_service_root().await })
+    }
+
+    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_systems().await })
+    }
+
+    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_managers().await })
+    }
+
+    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
+        Box::pin(async move { self.s.get_manager().await })
+    }
+
+    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
+    }
+
+    fn get_job_state<'a>(
+        &'a self,
+        job_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
+        Box::pin(async move { self.s.get_job_state(job_id).await })
+    }
+
+    fn get_collection<'a>(
+        &'a self,
+        id: ODataId,
+    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
+        Box::pin(async move { self.s.get_collection(id).await })
+    }
+
+    fn get_resource<'a>(
+        &'a self,
+        id: ODataId,
+    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
+        Box::pin(async move { self.s.get_resource(id).await })
+    }
+
+    fn set_boot_order_dpu_first<'a>(
+        &'a self,
+        boot_interface: crate::BootInterfaceRef<'a>,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            let address = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let mac_address = address.replace(':', "").to_uppercase();
+            let boot_option_name =
+                format!("{} (MAC:{})", BootOptionName::Http.to_string(), mac_address);
+            let boot_array = self
+                .get_boot_options_ids_with_first(
+                    BootOptionName::Http,
+                    BootOptionMatchField::DisplayName,
+                    Some(&boot_option_name),
+                )
+                .await?;
+            self.change_boot_order(boot_array).await?;
+            Ok(None)
+        })
+    }
+
+    fn clear_uefi_password<'a>(
+        &'a self,
+        current_uefi_password: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
+    }
+
+    fn get_base_mac_address<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_base_mac_address().await })
+    }
+
+    fn lockdown_bmc<'a>(
+        &'a self,
+        target: crate::EnabledDisabled,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.lockdown_bmc(target).await })
+    }
+
+    fn is_ipmi_over_lan_enabled<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
+        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
+    }
+
+    fn enable_ipmi_over_lan<'a>(
+        &'a self,
+        target: crate::EnabledDisabled,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
+    }
+
+    fn update_firmware_simple_update<'a>(
+        &'a self,
+        image_uri: &'a str,
+        targets: Vec<String>,
+        transfer_protocol: TransferProtocolType,
+    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
+                .await
+        })
+    }
+
+    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.enable_rshim_bmc().await })
+    }
+
+    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.clear_nvram().await })
+    }
+
+    fn get_nic_mode<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
+        Box::pin(async move { self.s.get_nic_mode().await })
+    }
+
+    fn set_nic_mode<'a>(
+        &'a self,
+        mode: NicMode,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_nic_mode(mode).await })
+    }
+
+    fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            let attrs: HashMap<String, serde_json::Value> =
+                HashMap::from([("EmbeddedUefiShell".to_string(), "Disabled".into())]);
+            let body = HashMap::from([("Attributes", attrs)]);
+            let url = format!("Systems/{}/Bios/Settings", self.s.system_id());
+            self.s.client.patch(&url, body).await.map(|_status_code| ())
+        })
+    }
+
+    fn is_infinite_boot_enabled<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            let embedded_uefi_shell = self.get_embedded_uefi_shell_status().await?;
+            // Infinite boot is enabled when EmbeddedUefiShell is disabled
+            Ok(Some(embedded_uefi_shell == EnabledDisabled::Disabled))
+        })
+    }
+
+    fn set_host_rshim<'a>(
+        &'a self,
+        enabled: EnabledDisabled,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_host_rshim(enabled).await })
+    }
+
+    fn get_host_rshim<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
+        Box::pin(async move { self.s.get_host_rshim().await })
+    }
+
+    fn set_idrac_lockdown<'a>(
+        &'a self,
+        enabled: EnabledDisabled,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
+    }
+
+    fn get_boss_controller<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_boss_controller().await })
+    }
+
+    fn decommission_storage_controller<'a>(
+        &'a self,
+        controller_id: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
+    }
+
+    fn create_storage_volume<'a>(
+        &'a self,
+        controller_id: &'a str,
+        volume_name: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .create_storage_volume(controller_id, volume_name)
+                .await
+        })
+    }
+
+    fn is_boot_order_setup<'a>(
+        &'a self,
+        boot_interface: crate::BootInterfaceRef<'a>,
+    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
+        Box::pin(async move {
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let (expected, actual) = self.get_expected_and_actual_first_boot_option(&mac).await?;
+            Ok(expected.is_some() && expected == actual)
+        })
+    }
+
+    fn is_bios_setup<'a>(
+        &'a self,
+        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
+    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
+        Box::pin(async move {
+            let diffs = self.diff_bios_bmc_attr().await?;
+            Ok(diffs.is_empty())
+        })
+    }
+
+    fn get_component_integrities<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
+        Box::pin(async move { self.s.get_component_integrities().await })
+    }
+
+    fn get_firmware_for_component<'a>(
+        &'a self,
+        component_integrity_id: &'a str,
+    ) -> crate::RedfishFuture<
+        'a,
+        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
+    > {
+        Box::pin(async move {
+            let mut id = None;
+
+            for value in get_component_integrity_id_to_firmware_inventory_id_options()? {
+                if let Some(capture) = value.pattern.captures(component_integrity_id) {
+                    id = Some(format!(
+                        "{}{}",
+                        value.id_prefix,
+                        capture
+                            .get(1)
+                            .ok_or_else(|| RedfishError::GenericError {
+                                error: format!(
+                                    "Empty capture for {}, id_prefix: {}",
+                                    component_integrity_id, value.id_prefix
+                                )
+                            })?
+                            .as_str()
+                    ));
+                    break;
+                }
+            }
+
+            let Some(id) = id else {
+                return Err(RedfishError::NotSupported(format!(
+                    "No component match for {}",
+                    component_integrity_id
+                )));
+            };
+            self.get_firmware(&id).await
+        })
+    }
+
+    fn get_component_ca_certificate<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> crate::RedfishFuture<
+        'a,
+        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
+    > {
+        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
+    }
+
+    fn trigger_evidence_collection<'a>(
+        &'a self,
+        url: &'a str,
+        nonce: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
+        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
+    }
+
+    fn get_evidence<'a>(
+        &'a self,
+        url: &'a str,
+    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
+    {
+        Box::pin(async move { self.s.get_evidence(url).await })
+    }
+
+    fn set_host_privilege_level<'a>(
+        &'a self,
+        level: HostPrivilegeLevel,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_host_privilege_level(level).await })
+    }
+
+    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_utc_timezone().await })
+    }
+
+    fn set_ntp_servers<'a>(
+        &'a self,
+        servers: &'a [String],
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+    }
+}
+
+impl Bmc {
+    /// Check BIOS and BMC attributes and return differences
+    async fn diff_bios_bmc_attr(&self) -> Result<Vec<MachineSetupDiff>, RedfishError> {
+        let mut diffs = vec![];
+
+        // Check BIOS and BMC attributes
+        let sb = self.get_secure_boot().await?;
+        if sb.secure_boot_enable.unwrap_or(false) {
+            diffs.push(MachineSetupDiff {
+                key: "SecureBoot".to_string(),
+                expected: "false".to_string(),
+                actual: "true".to_string(),
+            });
+        }
+
+        let bios = self.s.bios_attributes().await?;
+        let expected_attrs = self.machine_setup_attrs().await?;
+        for (key, expected) in expected_attrs {
+            let Some(actual) = bios.get(&key) else {
+                diffs.push(MachineSetupDiff {
+                    key: key.to_string(),
+                    expected: expected.to_string(),
+                    actual: "_missing_".to_string(),
+                });
+                continue;
+            };
+            // expected and actual are serde_json::Value which are not comparable, so to_string
+            let act = actual.to_string();
+            let exp = expected.to_string();
+            if act != exp {
+                diffs.push(MachineSetupDiff {
+                    key: key.to_string(),
+                    expected: exp,
+                    actual: act,
+                });
+            }
+        }
+
+        Ok(diffs)
+    }
+
+    async fn get_expected_and_actual_first_boot_option(
+        &self,
+        boot_interface_mac: &str,
+    ) -> Result<(Option<String>, Option<String>), RedfishError> {
+        let mac_address = boot_interface_mac.replace(':', "").to_uppercase();
+        let boot_option_name =
+            format!("{} (MAC:{})", BootOptionName::Http.to_string(), mac_address);
+
+        let boot_options = self.s.get_system().await?.boot.boot_order;
+
+        let actual_first_boot_option = if let Some(first) = boot_options.first() {
+            Some(self.s.get_boot_option(first.as_str()).await?.display_name)
+        } else {
+            None
+        };
+
+        let mut expected_first_boot_option = None;
+        for member in &boot_options {
+            let b = self.s.get_boot_option(member.as_str()).await?;
+            if b.display_name.starts_with(&boot_option_name) {
+                expected_first_boot_option = Some(b.display_name);
+                break;
+            }
+        }
+
+        Ok((expected_first_boot_option, actual_first_boot_option))
+    }
+
+    // name: The name of the device you want to make the first boot choice.
+    async fn set_boot_order(&self, name: BootOptionName) -> Result<(), RedfishError> {
+        let boot_array = self
+            .get_boot_options_ids_with_first(name, BootOptionMatchField::DisplayName, None)
+            .await?;
+        self.change_boot_order(boot_array).await
+    }
+
+    // This function searches all reported boot options to find the
+    // desired option, then prepends it to the existing boot order.
+    async fn get_boot_options_ids_with_first(
+        &self,
+        with_name: BootOptionName,
+        match_field: BootOptionMatchField,
+        with_name_str: Option<&str>,
+    ) -> Result<Vec<String>, RedfishError> {
+        let name_str = with_name_str.unwrap_or(with_name.to_string());
+        let system = self.s.get_system().await?;
+
+        let boot_options_id =
+            system
+                .boot
+                .boot_options
+                .clone()
+                .ok_or_else(|| RedfishError::MissingKey {
+                    key: "boot.boot_options".to_string(),
+                    url: system.odata.odata_id.clone(),
+                })?;
+
+        let all_boot_options: Vec<BootOption> = self
+            .get_collection(boot_options_id)
+            .await
+            .and_then(|c| c.try_get::<BootOption>())?
+            .members;
+
+        // Search through all boot options to find the one we want
+        let found_boot_option = all_boot_options.iter().find(|b| match match_field {
+            BootOptionMatchField::DisplayName => b.display_name.starts_with(name_str),
+            BootOptionMatchField::UefiDevicePath => {
+                matches!(&b.uefi_device_path, Some(x) if x.starts_with(name_str))
+            }
+        });
+
+        let Some(target) = found_boot_option else {
+            let all_names: Vec<_> = all_boot_options
+                .iter()
+                .map(|b| format!("{}: {}", b.id, b.display_name))
+                .collect();
+            return Err(RedfishError::GenericError {
+                error: format!(
+                    "Could not find boot option matching {name_str} on {}; all boot options: {:#?}",
+                    match_field, all_names
+                ),
+            });
+        };
+
+        let target_id = target.id.clone();
+
+        // Prepend the found option to the front of the existing boot order
+        let mut ordered = system.boot.boot_order;
+        ordered.retain(|id| id != &target_id);
+        ordered.insert(0, target_id);
+
+        Ok(ordered)
+    }
+
+    async fn get_system_event_log(&self) -> Result<Vec<LogEntry>, RedfishError> {
+        let url = format!("Systems/{}/LogServices/SEL/Entries", self.s.system_id());
+        let (_status_code, log_entry_collection): (_, LogEntryCollection) =
+            self.s.client.get(&url).await?;
+        let log_entries = log_entry_collection.members;
+        Ok(log_entries)
+    }
+
+    async fn machine_setup_attrs(&self) -> Result<Vec<(String, serde_json::Value)>, RedfishError> {
+        Ok(vec![
+            ("TPM".into(), "Enabled".into()),
+            ("EmbeddedUefiShell".into(), "Disabled".into()),
+            ("GpuExposeAsPcie".into(), true.into()),
+        ])
+    }
+
+    // get_embedded_uefi_shell_status returns the current status of the EmbeddedUefiShell BIOS attribute.
+    async fn get_embedded_uefi_shell_status(&self) -> Result<EnabledDisabled, RedfishError> {
+        let url = format!("Systems/{}/Bios", self.s.system_id());
+        let bios_value = self.s.bios_attributes().await?;
+        let bios_attributes =
+            bios_value
+                .as_object()
+                .ok_or_else(|| RedfishError::InvalidKeyType {
+                    key: "Attributes".to_string(),
+                    expected_type: "object".to_string(),
+                    url: url.clone(),
+                })?;
+
+        let embedded_uefi_shell = jsonmap::get_str(bios_attributes, "EmbeddedUefiShell", &url)?;
+
+        match embedded_uefi_shell {
+            "Enabled" => Ok(EnabledDisabled::Enabled),
+            "Disabled" => Ok(EnabledDisabled::Disabled),
+            _ => Err(RedfishError::InvalidValue {
+                url,
+                field: "EmbeddedUefiShell".to_string(),
+                err: crate::model::InvalidValueError(format!(
+                    "Expected 'Enabled' or 'Disabled', got '{}'",
+                    embedded_uefi_shell
+                )),
+            }),
+        }
+    }
+}
+
+// UpdateParameters is what is sent for a multipart firmware upload's metadata.
+#[derive(Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct UpdateParameters {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    targets: Option<Vec<String>>,
+    force_update: bool,
+}
+
+impl UpdateParameters {
+    pub fn new(component: ComponentType) -> UpdateParameters {
+        let targets = match component {
+            ComponentType::Unknown => None,
+            ComponentType::BMC => Some(vec![]),
+            ComponentType::EROTBMC => Some(vec!["/redfish/v1/Chassis/HGX_ERoT_BMC_0".to_string()]),
+            ComponentType::EROTBIOS => Some(vec![
+                "/redfish/v1/UpdateService/FirmwareInventory/EROT_BIOS_0".to_string(),
+            ]),
+            ComponentType::HGXBMC | ComponentType::UEFI => {
+                Some(vec!["/redfish/v1/Chassis/HGX_Chassis_0".to_string()])
+            }
+            _ => Some(vec!["unreachable".to_string()]),
+        };
+
+        UpdateParameters {
+            targets,
+            force_update: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_update_parameters_targets_all_variants() {
+        let cases: Vec<(ComponentType, Option<Vec<String>>)> = vec![
+            (ComponentType::Unknown, None),
+            (ComponentType::BMC, Some(vec![])),
+            (
+                ComponentType::EROTBMC,
+                Some(vec!["/redfish/v1/Chassis/HGX_ERoT_BMC_0".to_string()]),
+            ),
+            (
+                ComponentType::EROTBIOS,
+                Some(vec![
+                    "/redfish/v1/UpdateService/FirmwareInventory/EROT_BIOS_0".to_string(),
+                ]),
+            ),
+            (
+                ComponentType::HGXBMC,
+                Some(vec!["/redfish/v1/Chassis/HGX_Chassis_0".to_string()]),
+            ),
+            (
+                ComponentType::UEFI,
+                Some(vec!["/redfish/v1/Chassis/HGX_Chassis_0".to_string()]),
+            ),
+            (
+                ComponentType::CPLDMID,
+                Some(vec!["unreachable".to_string()]),
+            ),
+            (ComponentType::CPLDMB, Some(vec!["unreachable".to_string()])),
+            (
+                ComponentType::CPLDPDB,
+                Some(vec!["unreachable".to_string()]),
+            ),
+            (
+                ComponentType::PSU { num: 1 },
+                Some(vec!["unreachable".to_string()]),
+            ),
+            (
+                ComponentType::PCIeSwitch { num: 2 },
+                Some(vec!["unreachable".to_string()]),
+            ),
+            (
+                ComponentType::PCIeRetimer { num: 3 },
+                Some(vec!["unreachable".to_string()]),
+            ),
+        ];
+
+        for (component, expected_targets) in cases {
+            let params = UpdateParameters::new(component.clone());
+            assert_eq!(
+                params.targets, expected_targets,
+                "Failed for component: {:?}",
+                component
+            );
+            assert!(
+                params.force_update,
+                "Force update not true for: {:?}",
+                component
+            );
+        }
+    }
+}

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -1317,6 +1317,9 @@ impl RedfishStandard {
             RedfishVendor::NvidiaGBx00 => {
                 Ok(Box::new(crate::nvidia_gbx00::Bmc::new(self.clone())?))
             }
+            RedfishVendor::VeraRubin => {
+                Ok(Box::new(crate::nvidia_vera_rubin::Bmc::new(self.clone())?))
+            }
             RedfishVendor::NvidiaGBSwitch => {
                 Ok(Box::new(crate::nvidia_gbswitch::Bmc::new(self.clone())?))
             }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -126,6 +126,7 @@ async fn test_nvidia_gb200() -> Result<(), anyhow::Error> {
 }
 
 #[tokio::test]
+#[ignore = "VR redfish not available"]
 async fn test_nvidia_vera_rubin() -> Result<(), anyhow::Error> {
     run_integration_test("nvidia_vera_rubin", NVIDIA_VERA_RUBIN_PORT).await
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -62,6 +62,7 @@ const SUPERMICRO_PORT: &str = "8738";
 const DELL_MULTI_DPU_PORT: &str = "8739";
 const NVIDIA_GH200_PORT: &str = "8740";
 const NVIDIA_GB200_PORT: &str = "8741";
+const NVIDIA_VERA_RUBIN_PORT: &str = "8745";
 const NVIDIA_GBSWITCH_PORT: &str = "8742";
 const LITEON_POWERSHELF_PORT: &str = "8743";
 const DELTA_POWERSHELF_PORT: &str = "8744";
@@ -122,6 +123,11 @@ async fn test_supermicro() -> Result<(), anyhow::Error> {
 #[tokio::test]
 async fn test_nvidia_gb200() -> Result<(), anyhow::Error> {
     run_integration_test("nvidia_gb200", NVIDIA_GB200_PORT).await
+}
+
+#[tokio::test]
+async fn test_nvidia_vera_rubin() -> Result<(), anyhow::Error> {
+    run_integration_test("nvidia_vera_rubin", NVIDIA_VERA_RUBIN_PORT).await
 }
 
 #[tokio::test]
@@ -345,6 +351,7 @@ async fn run_integration_test(
 
     if vendor_dir != "nvidia_gh200"
         && vendor_dir != "nvidia_gb200"
+        && vendor_dir != "nvidia_vera_rubin"
         && vendor_dir != "nvidia_gbswitch"
         && vendor_dir != "liteon_powershelf"
         && vendor_dir != "delta_powershelf"
@@ -428,6 +435,7 @@ async fn run_integration_test(
 
     if vendor_dir != "nvidia_gh200"
         && vendor_dir != "nvidia_gb200"
+        && vendor_dir != "nvidia_vera_rubin"
         && vendor_dir != "nvidia_gbswitch"
         && vendor_dir != "liteon_powershelf"
         && vendor_dir != "delta_powershelf"
@@ -442,6 +450,7 @@ async fn run_integration_test(
     if vendor_dir != "supermicro"
         && vendor_dir != "nvidia_gh200"
         && vendor_dir != "nvidia_gb200"
+        && vendor_dir != "nvidia_vera_rubin"
         && vendor_dir != "nvidia_gbswitch"
         && vendor_dir != "liteon_powershelf"
         && vendor_dir != "delta_powershelf"
@@ -604,7 +613,7 @@ async fn run_integration_test(
         && vendor_dir != "delta_powershelf"
     {
         let tm = redfish.get_thermal_metrics().await?;
-        if vendor_dir == "nvidia_gb200" {
+        if vendor_dir == "nvidia_gb200" || vendor_dir == "nvidia_vera_rubin" {
             assert!(tm.leak_detectors.is_some());
         }
         if vendor_dir != "nvidia_gbswitch" {
@@ -673,6 +682,7 @@ async fn run_integration_test(
             ("lenovo", 1),
             ("supermicro", 2),
             ("nvidia_gb200", 4),
+            ("nvidia_vera_rubin", 4),
             ("dell_multi_dpu", 16),
             ("hpe", 2),
         ]
@@ -688,6 +698,7 @@ async fn run_integration_test(
             ("lenovo", 4),
             ("supermicro", 8),
             ("nvidia_gb200", 9),
+            ("nvidia_vera_rubin", 9),
             ("dell_multi_dpu", 2),
             ("hpe", 18),
         ]
@@ -703,6 +714,7 @@ async fn run_integration_test(
             ("lenovo", 15),
             ("supermicro", 26),
             ("nvidia_gb200", 0), // have no pcie devices
+            ("nvidia_vera_rubin", 0),
             ("dell_multi_dpu", 10),
             ("hpe", 6),
         ]
@@ -814,7 +826,7 @@ async fn resource_tests(redfish: &dyn Redfish) -> Result<(), anyhow::Error> {
             result
         }
         RedfishVendor::NvidiaGH200 => "BMC_0",
-        RedfishVendor::NvidiaGBx00 => "Chassis_0", // this is not the catch-all chassis id, gb200 redfish is not structured to aggregate into one chassis id
+        RedfishVendor::NvidiaGBx00 | RedfishVendor::VeraRubin => "Chassis_0", // this is not the catch-all chassis id, gb200 redfish is not structured to aggregate into one chassis id
         RedfishVendor::NvidiaGBSwitch => "MGX_NVSwitch_0",
         _ => return Err(anyhow!("Unknown vendor could not identify chassis")),
     };


### PR DESCRIPTION
Add support for the new NVIDIA Vera Rubin vendor.

**Related issues**
(https://jirasw.nvidia.com/browse/FORGE-8111)

The new nvidia_vera_rubin.rs implementation is largely identical to nvidia_gbx00.rs, with the following BIOS attribute differences:

`Pcie6DisableOptionROM` is not present on Vera Rubin systems.
Vera Rubin introduces a new `GpuExposeAsPcie` field.
Testing

Tested against a real Vera Rubin host BMC using a locally built nico-admin-cli with this libredfish branch.

Verified the raw Redfish BIOS attributes:

```
kubectl -n forge-system exec $POD -- curl -sk -u "$USER:$PASS" \
  "https://$BMC/redfish/v1/Systems/System_0/Bios" \
  | grep -E 'GpuExposeAsPcie|Pcie6DisableOptionROM|TPM|EmbeddedUefiShell'
```

Output:

```
"EmbeddedUefiShell": "Enabled",
"GpuExposeAsPcie": true,
"TPM": "Enabled",
```

Verified bios-attrs correctly exposes the Vera Rubin BIOS attributes:

```
/tmp/nico-admin-cli-Hamed redfish \
  --address $BMC \
  --username $USER \
  --password $PASS \
  bios-attrs | jq '.Attributes | {TPM, EmbeddedUefiShell, GpuExposeAsPcie}'
```

Output:
```

{
  "TPM": "Enabled",
  "EmbeddedUefiShell": "Enabled",
  "GpuExposeAsPcie": true
}
```

Verified machine-setup-status behavior against the real host BMC:

```
/tmp/nico-admin-cli-Hamed redfish \
  --address $BMC \
  --username $USER \
  --password $PASS \
  machine-setup-status \
  --boot-interface-mac CE:FF:86:96:ED:B7
```

Output:

Mismatch: "EmbeddedUefiShell is '\"Enabled\"' expected '\"Disabled\"', boot_first is 'Ubuntu' expected 'UEFI HTTPv4 (MAC:CEFF8696EDB7)'"

The same DPU MAC, CEFF8696EDB7, has multiple boot entries, including UEFI PXEv4, UEFI PXEv6, UEFI HTTPv4, and UEFI HTTPv6. libredfish correctly selects the HTTPv4 entry by DisplayName prefix.

Also verified the thermal-metrics deserialization fix.

Before this change:

```
/tmp/nico-admin-cli-Hamed redfish \
  --address $BMC \
  --username $USER \
  --password $PASS \
  thermal-metrics
```

Output:

```
Error:
   0: Could not deserialize response from https://10.73.114.74/redfish/v1/Chassis/BMC_0/ThermalSubsystem/ThermalMetrics.

After this change:

/tmp/nico-admin-cli-Hamed redfish \
  --address $BMC \
  --username $USER \
  --password $PASS \
  thermal-metrics

Output:

{
  "@odata.context": null,
  "@odata.id": "",
  "@odata.type": "",
  "@odata.etag": null,
  "links": null,
  "Id": "",
  "Name": "",
  "Fans": [],
  "Temperatures": [
    {
      "Name": "BMC_0_Temp_0",
      "SensorNumber": null,
      "LowerThresholdCritical": null,
      "LowerThresholdFatal": null,
      "PhysicalContext": null,
      "ReadingCelsius": 56.187000000000005
    }
  ]
}
```