### PR TITLE
fix(dell): support extended HTTP boot option names

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -89,6 +89,13 @@ fn nw_dev_func_matches(
     }
 }
 
+fn boot_option_name_matches(expected: &str, actual: &str) -> bool {
+    actual == expected
+        || actual
+            .strip_prefix(expected)
+            .is_some_and(|suffix| suffix.starts_with(" - "))
+}
+
 pub struct Bmc {
     s: RedfishStandard,
 }
@@ -405,7 +412,11 @@ impl Redfish for Bmc {
                 let (expected, actual) = self
                     .get_expected_and_actual_first_boot_option(boot_interface)
                     .await?;
-                if expected.is_none() || expected != actual {
+                if !matches!(
+                    (&expected, &actual),
+                    (Some(expected), Some(actual))
+                        if boot_option_name_matches(expected, actual)
+                ) {
                     diffs.push(MachineSetupDiff {
                         key: "boot_first".to_string(),
                         expected: expected.unwrap_or_else(|| "Not found".to_string()),
@@ -1122,7 +1133,7 @@ impl Redfish for Bmc {
                 .await?;
             let boot_order = self.get_boot_order().await?;
             for (idx, boot_option) in boot_order.iter().enumerate() {
-                if boot_option.display_name == expected_boot_option_name {
+                if boot_option_name_matches(&expected_boot_option_name, &boot_option.display_name) {
                     if idx == 0 {
                         // Dells will not generate a bios config job below if the boot orders already configured correctly
                         tracing::info!(
@@ -1328,7 +1339,10 @@ impl Redfish for Bmc {
             let (expected, actual) = self
                 .get_expected_and_actual_first_boot_option(boot_interface)
                 .await?;
-            Ok(expected.is_some() && expected == actual)
+            Ok(matches!(
+                (&expected, &actual),
+                (Some(expected), Some(actual)) if boot_option_name_matches(expected, actual)
+            ))
         })
     }
 
@@ -2756,7 +2770,7 @@ impl std::fmt::Display for XmlPcdata<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::{nw_dev_func_matches, XmlPcdata};
+    use super::{boot_option_name_matches, nw_dev_func_matches, XmlPcdata};
     use crate::model::network_device_function::{Ethernet, NetworkDeviceFunction};
     use crate::BootInterfaceRef;
     use std::collections::HashMap;
@@ -2816,6 +2830,38 @@ mod tests {
         let populated = ndf_with(Some("NIC.Slot.40-1-1"), Some("c4:70:bd:2c:3c:0a"));
         let mac: mac_address::MacAddress = "C4:70:BD:2C:3C:0A".parse().unwrap();
         assert!(nw_dev_func_matches(&populated, BootInterfaceRef::Mac(mac)));
+    }
+
+    #[test]
+    fn boot_option_name_matches_legacy_and_extended_names() {
+        let expected = "HTTP Device 1: NIC in Slot 4 Port 1 Partition 1";
+        let cases = [
+            (expected, true),
+            (
+                "HTTP Device 1: NIC in Slot 4 Port 1 Partition 1 - Nvidia Network Adapter - 00:11:22:33:44:55 - IPv4",
+                true,
+            ),
+            (
+                "HTTP Device 1: NIC in Slot 4 Port 1 Partition 10 - Nvidia Network Adapter - 00:11:22:33:44:55 - IPv4",
+                false,
+            ),
+            (
+                "HTTP Device 1: NIC in Slot 4 Port 2 Partition 1 - Nvidia Network Adapter - 00:11:22:33:44:55 - IPv4",
+                false,
+            ),
+            (
+                "HTTP Device 1: NIC in Slot 4 Port 1 Partition 1 unexpected suffix",
+                false,
+            ),
+        ];
+
+        for (actual, should_match) in cases {
+            assert_eq!(
+                boot_option_name_matches(expected, actual),
+                should_match,
+                "unexpected match result for {actual}"
+            );
+        }
     }
 
     // Mirrors the attribute-merge logic in machine_setup_oem so we can test it


### PR DESCRIPTION
## Summary

- recognize both legacy exact Dell HTTP boot-option names and newer names with a `" - "`-delimited adapter/MAC/protocol suffix
- use one bounded matcher in `machine_setup_status`, `set_boot_order_dpu_first`, and `is_boot_order_setup`
- prevent false prefix matches such as `Partition 1` matching `Partition 10`
- add table-driven regression coverage for legacy, extended, and non-matching names

## Testing

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features --workspace -- -D warnings`
- `cargo build`
- `cargo test --locked -- --test-threads=1`
- focused `test_dell` integration test
- focused `test_dell_multi_dpu` integration test

Fixes #101.

Related: #93. This is a draft fallback for the existing fix; only one implementation should be merged.