### PR TITLE
fix: support BIOS reset on NVIDIA GBx00 and GH200

### DIFF
--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -813,7 +813,7 @@ impl Redfish for Bmc {
     }
 
     fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.reset_bios().await })
+        Box::pin(async move { self.s.factory_reset_bios().await })
     }
 
     fn pending<'a>(

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -497,7 +497,7 @@ impl Redfish for Bmc {
     }
 
     fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.reset_bios().await })
+        Box::pin(async move { self.s.factory_reset_bios().await })
     }
 
     /// gh200 has no bios attributes

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -1513,9 +1513,9 @@ impl RedfishStandard {
     pub async fn factory_reset_bios(&self) -> Result<(), RedfishError> {
         let url = format!("Systems/{}/Bios/Actions/Bios.ResetBios", self.system_id());
         self.client
-            .req::<(), ()>(Method::POST, &url, None, None, None, Vec::new())
+            .post(&url, HashMap::<String, String>::new())
             .await
-            .map(|_resp| Ok(()))?
+            .map(|_| ())
     }
 
     pub async fn get_account_by_id(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -247,6 +247,8 @@ async fn nvidia_dpu_integration_test(redfish: &dyn Redfish) -> Result<(), anyhow
         .get("CommonName")
         .is_some_and(|x| x.as_str().unwrap().contains("NVIDIA BlueField")));
 
+    redfish.reset_bios().await?;
+
     Ok(())
 }
 
@@ -403,6 +405,21 @@ async fn run_integration_test(
         && vendor_dir != "delta_powershelf"
     {
         assert!(redfish.bios().await?.len() > 8);
+    }
+
+    // Exercise vendor-specific BIOS reset dispatch. The mock server validates
+    // that the target resource or action exists, but does not apply the reset.
+    if matches!(
+        vendor_dir,
+        "dell"
+            | "dell_multi_dpu"
+            | "lenovo"
+            | "supermicro"
+            | "nvidia_viking"
+            | "nvidia_gb200"
+            | "nvidia_gh200"
+    ) {
+        redfish.reset_bios().await?;
     }
 
     // Delta power shelves expose no `/Systems` resource, so there is no


### PR DESCRIPTION
## Summary

Enable BIOS factory reset for NVIDIA GBx00 and GH200 systems.

The vendor implementations previously delegated to `RedfishStandard::reset_bios()`, which returned `NotSupported`, so no reset request was sent to the BMC.

## Changes

- Route NVIDIA GBx00 BIOS reset through `factory_reset_bios()`.
- Route NVIDIA GH200 BIOS reset through `factory_reset_bios()`.
- Send an explicit empty JSON object for the parameterless `Bios.ResetBios` action.
- Add integration coverage for the existing supported BIOS-reset paths:
  - Dell
  - Dell multi-DPU
  - Lenovo
  - Supermicro
  - NVIDIA Viking
  - NVIDIA GB200
  - NVIDIA GH200
  - NVIDIA DPU