### PR TITLE
fix(dell): clear pending job queue before staging boot-order change

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1142,6 +1142,14 @@ impl Redfish for Bmc {
                         return Ok(None);
                     }
 
+                    // Clear any committed-but-unapplied pending config first, as
+                    // the sibling BIOS-config writers do (machine_setup,
+                    // setup_serial_console, clear_tpm, change_uefi_password): on
+                    // Dell a staged pending config makes this PATCH fail with
+                    // SYS011 ("pending configuration values are already
+                    // committed").
+                    self.delete_job_queue().await?;
+
                     let url = format!("Systems/{}/Settings", self.s.system_id());
                     let body = HashMap::from([(
                         "Boot",


### PR DESCRIPTION
set_boot_order_dpu_first PATCHed .../Settings without first clearing the job queue, unlike the sibling config writers (machine_setup, setup_serial_console, clear_tpm, change_uefi_password). On Dell, a committed-but-unapplied pending config makes the PATCH fail with SYS011 ("pending configuration values are already committed"), which wedged the machine-controller SetBootOrder loop indefinitely.

Clear the queue immediately before the PATCH (after the already-first no-op check) so a stale pending config no longer blocks the boot-order set.
