### PR TITLE
fix: align boot interface apply and verification

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -28,7 +28,7 @@ use crate::{
     model::{
         account_service::ManagerAccount,
         boot::{
-            BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
+            self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
             BootSourceOverrideTarget,
         },
         certificate::Certificate,
@@ -75,6 +75,82 @@ fn lockdown_status_from(message: String, is_locked: bool, is_unlocked: bool) -> 
             StatusInternal::Partial
         },
     }
+}
+
+fn is_target_or_network_boot_option(option: &BootOption, target_reference: &str) -> bool {
+    option.boot_option_reference == target_reference
+        || matches!(option.alias.as_deref(), Some("Pxe" | "UefiHttp"))
+}
+
+fn find_boot_option_for_mac<'a>(
+    boot_options: &'a [BootOption],
+    boot_interface_mac: &str,
+) -> Option<&'a BootOption> {
+    let mac = boot_interface_mac.to_uppercase();
+    boot_options.iter().find(|option| {
+        let display = option.display_name.to_uppercase();
+        display.contains("HTTP") && display.contains("IPV4") && display.contains(&mac)
+    })
+}
+
+fn compare_boot_order(
+    vendor: Option<RedfishVendor>,
+    boot_order: &[String],
+    boot_options: &[BootOption],
+    boot_interface_mac: &str,
+) -> Vec<MachineSetupDiff> {
+    let mut diffs = Vec::new();
+    let target = find_boot_option_for_mac(boot_options, boot_interface_mac);
+    let actual_first_reference = boot_order
+        .first()
+        .map(|entry| boot::boot_order_entry_reference(entry));
+
+    let target_is_first = target.is_some_and(|option| {
+        actual_first_reference == Some(option.boot_option_reference.as_str())
+    });
+    if !target_is_first {
+        let expected = target
+            .map(|option| option.display_name.clone())
+            .unwrap_or_else(|| "Not found".to_string());
+        let actual = actual_first_reference
+            .and_then(|reference| {
+                boot_options
+                    .iter()
+                    .find(|option| option.boot_option_reference == reference)
+            })
+            .map(|option| option.display_name.clone())
+            .unwrap_or_else(|| "Not found".to_string());
+        diffs.push(MachineSetupDiff {
+            key: "boot_first".to_string(),
+            expected,
+            actual,
+        });
+    }
+
+    if vendor != Some(RedfishVendor::LenovoGB300) {
+        return diffs;
+    }
+    let Some(target) = target else {
+        return diffs;
+    };
+    for option in boot_options
+        .iter()
+        .filter(|option| is_target_or_network_boot_option(option, &target.boot_option_reference))
+    {
+        let expected = option.boot_option_reference == target.boot_option_reference;
+        if option.boot_option_enabled != Some(expected) {
+            diffs.push(MachineSetupDiff {
+                key: format!("BootOptions/{}/BootOptionEnabled", option.id),
+                expected: expected.to_string(),
+                actual: option
+                    .boot_option_enabled
+                    .map(|enabled| enabled.to_string())
+                    .unwrap_or_else(|| "_missing_".to_string()),
+            });
+        }
+    }
+
+    diffs
 }
 
 pub struct Bmc {
@@ -431,15 +507,7 @@ impl Redfish for Bmc {
             let mut diffs = self.diff_bios_bmc_attr().await?;
 
             if let Some(mac) = boot_interface_mac {
-                let (expected, actual) =
-                    self.get_expected_and_actual_first_boot_option(mac).await?;
-                if expected.is_none() || expected != actual {
-                    diffs.push(MachineSetupDiff {
-                        key: "boot_first".to_string(),
-                        expected: expected.unwrap_or_else(|| "Not found".to_string()),
-                        actual: actual.unwrap_or_else(|| "Not found".to_string()),
-                    });
-                }
+                diffs.extend(self.boot_order_diffs(mac).await?);
             }
 
             let lockdown = self.lockdown_status().await?;
@@ -1042,10 +1110,7 @@ impl Redfish for Bmc {
                 .to_uppercase();
             let (system, all_boot_options) = self.get_system_and_boot_options().await?;
 
-            let target = all_boot_options.iter().find(|opt| {
-                let display = opt.display_name.to_uppercase();
-                display.contains("HTTP") && display.contains("IPV4") && display.contains(&mac)
-            });
+            let target = find_boot_option_for_mac(&all_boot_options, &mac);
 
             let Some(target) = target else {
                 let all_names: Vec<_> = all_boot_options
@@ -1061,19 +1126,22 @@ impl Redfish for Bmc {
             let target_id = target.boot_option_reference.clone();
             let mut boot_order = system.boot.boot_order;
 
-            let boot_order_is_set = boot_order.first() == Some(&target_id);
+            let boot_order_is_set = boot_order
+                .first()
+                .is_some_and(|entry| boot::boot_order_entry_reference(entry) == target_id);
             if boot_order_is_set {
                 tracing::info!("NO-OP: DPU ({mac}) is already first in boot order ({target_id})");
             } else {
-                boot_order.retain(|id| id != &target_id);
-                boot_order.insert(0, target_id.clone());
+                if !boot::promote_boot_order_entry_first(&mut boot_order, &target_id) {
+                    boot_order.insert(0, target_id.clone());
+                }
                 self.change_boot_order(boot_order).await?;
             }
 
             if self.s.vendor == Some(RedfishVendor::LenovoGB300) {
                 for option in all_boot_options
                     .iter()
-                    .filter(|option| matches!(option.alias.as_deref(), Some("Pxe" | "UefiHttp")))
+                    .filter(|option| is_target_or_network_boot_option(option, &target_id))
                 {
                     let should_be_enabled = option.boot_option_reference == target_id;
                     if option.boot_option_enabled != Some(should_be_enabled) {
@@ -1104,26 +1172,7 @@ impl Redfish for Bmc {
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
-            let (expected, actual) = self.get_expected_and_actual_first_boot_option(&mac).await?;
-            let Some(expected) = expected else {
-                return Ok(false);
-            };
-            if actual.as_deref() != Some(&expected) {
-                return Ok(false);
-            }
-
-            let network_options_setup = if self.s.vendor == Some(RedfishVendor::LenovoGB300) {
-                let (_, all_boot_options) = self.get_system_and_boot_options().await?;
-                all_boot_options
-                    .iter()
-                    .filter(|option| matches!(option.alias.as_deref(), Some("Pxe" | "UefiHttp")))
-                    .all(|option| {
-                        option.boot_option_enabled == Some(option.display_name == expected)
-                    })
-            } else {
-                true
-            };
-            Ok(network_options_setup)
+            Ok(self.boot_order_diffs(&mac).await?.is_empty())
         })
     }
 
@@ -1399,6 +1448,19 @@ impl Bmc {
         Ok((system, all_boot_options))
     }
 
+    async fn boot_order_diffs(
+        &self,
+        boot_interface_mac: &str,
+    ) -> Result<Vec<MachineSetupDiff>, RedfishError> {
+        let (system, boot_options) = self.get_system_and_boot_options().await?;
+        Ok(compare_boot_order(
+            self.s.vendor,
+            &system.boot.boot_order,
+            &boot_options,
+            boot_interface_mac,
+        ))
+    }
+
     /// Finds the first boot option matching the given alias and moves it to the front
     /// of the boot order.
     async fn set_boot_order(&self, alias: &str) -> Result<(), RedfishError> {
@@ -1431,44 +1493,17 @@ impl Bmc {
 
         let mut boot_order = system.boot.boot_order;
 
-        if boot_order.first() == Some(&target_ref) {
+        if boot_order
+            .first()
+            .is_some_and(|entry| boot::boot_order_entry_reference(entry) == target_ref)
+        {
             return Ok(());
         }
 
-        boot_order.retain(|id| id != &target_ref);
-        boot_order.insert(0, target_ref);
+        if !boot::promote_boot_order_entry_first(&mut boot_order, &target_ref) {
+            boot_order.insert(0, target_ref);
+        }
         self.change_boot_order(boot_order).await
-    }
-
-    /// Get expected and actual first boot option for checking boot order setup.
-    ///
-    /// AMI boot option format example:
-    /// DisplayName: "[Slot2]UEFI: HTTP IPv4 Nvidia Network Adapter - B8:E9:24:17:6D:72 P1"
-    /// BootOptionReference: "Boot0001"
-    ///
-    async fn get_expected_and_actual_first_boot_option(
-        &self,
-        boot_interface_mac: &str,
-    ) -> Result<(Option<String>, Option<String>), RedfishError> {
-        let mac = boot_interface_mac.to_uppercase();
-        let (system, all_boot_options) = self.get_system_and_boot_options().await?;
-
-        let expected_first_boot_option = all_boot_options
-            .iter()
-            .find(|opt| {
-                let display = opt.display_name.to_uppercase();
-                display.contains("HTTP") && display.contains("IPV4") && display.contains(&mac)
-            })
-            .map(|opt| opt.display_name.clone());
-
-        let actual_first_boot_option = system.boot.boot_order.first().and_then(|first_ref| {
-            all_boot_options
-                .iter()
-                .find(|opt| &opt.boot_option_reference == first_ref)
-                .map(|opt| opt.display_name.clone())
-        });
-
-        Ok((expected_first_boot_option, actual_first_boot_option))
     }
 
     /// Get the BIOS attributes for machine setup.
@@ -1660,6 +1695,197 @@ fn extract_ami_task_id(location: Option<&str>, body: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const BOOT_INTERFACE_MAC: &str = "B8:E9:24:17:6D:72";
+    const TARGET_DISPLAY_NAME: &str =
+        "[Slot2]UEFI: HTTP IPv4 Nvidia Network Adapter - B8:E9:24:17:6D:72 P1";
+
+    fn boot_option(
+        reference: &str,
+        alias: &str,
+        display_name: &str,
+        enabled: Option<bool>,
+    ) -> BootOption {
+        BootOption {
+            odata: Default::default(),
+            alias: Some(alias.to_string()),
+            description: None,
+            boot_option_enabled: enabled,
+            boot_option_reference: reference.to_string(),
+            display_name: display_name.to_string(),
+            id: reference.to_string(),
+            name: display_name.to_string(),
+            uefi_device_path: None,
+        }
+    }
+
+    fn boot_options(
+        target_enabled: Option<bool>,
+        other_network_enabled: Option<bool>,
+        disk_enabled: Option<bool>,
+    ) -> Vec<BootOption> {
+        vec![
+            boot_option("Boot0001", "UefiHttp", TARGET_DISPLAY_NAME, target_enabled),
+            boot_option(
+                "Boot0002",
+                "Pxe",
+                "UEFI PXEv4 Nvidia Network Adapter - 9C:6B:00:11:22:33",
+                other_network_enabled,
+            ),
+            boot_option("Boot0003", "Hdd", "UEFI Disk", disk_enabled),
+        ]
+    }
+
+    fn boot_order(references: &[&str]) -> Vec<String> {
+        references
+            .iter()
+            .map(|reference| reference.to_string())
+            .collect()
+    }
+
+    fn gb300_boot_order_diffs(
+        boot_order: &[String],
+        boot_options: &[BootOption],
+    ) -> Vec<MachineSetupDiff> {
+        compare_boot_order(
+            Some(RedfishVendor::LenovoGB300),
+            boot_order,
+            boot_options,
+            BOOT_INTERFACE_MAC,
+        )
+    }
+
+    fn assert_diff(
+        diff: &MachineSetupDiff,
+        expected_key: &str,
+        expected_value: &str,
+        actual_value: &str,
+    ) {
+        assert_eq!(diff.key, expected_key);
+        assert_eq!(diff.expected, expected_value);
+        assert_eq!(diff.actual, actual_value);
+    }
+
+    #[test]
+    fn gb300_boot_order_accepts_complete_configuration() {
+        let options = boot_options(Some(true), Some(false), Some(true));
+        let diffs = gb300_boot_order_diffs(&boot_order(&["Boot0001"]), &options);
+
+        assert!(diffs.is_empty());
+    }
+
+    #[test]
+    fn gb300_boot_order_accepts_decorated_boot_order_reference() {
+        let options = boot_options(Some(true), Some(false), Some(true));
+        let diffs = gb300_boot_order_diffs(
+            &boot_order(&["Boot0001: Selected network adapter"]),
+            &options,
+        );
+
+        assert!(diffs.is_empty());
+    }
+
+    #[test]
+    fn gb300_boot_order_reports_disabled_selected_option() {
+        let options = boot_options(Some(false), Some(false), Some(true));
+        let diffs = gb300_boot_order_diffs(&boot_order(&["Boot0001"]), &options);
+
+        assert_eq!(diffs.len(), 1);
+        assert_diff(
+            &diffs[0],
+            "BootOptions/Boot0001/BootOptionEnabled",
+            "true",
+            "false",
+        );
+    }
+
+    #[test]
+    fn gb300_boot_order_reports_disabled_selected_option_without_alias() {
+        let mut options = boot_options(Some(false), Some(false), Some(true));
+        options[0].alias = None;
+        let diffs = gb300_boot_order_diffs(&boot_order(&["Boot0001"]), &options);
+
+        assert_eq!(diffs.len(), 1);
+        assert_diff(
+            &diffs[0],
+            "BootOptions/Boot0001/BootOptionEnabled",
+            "true",
+            "false",
+        );
+    }
+
+    #[test]
+    fn gb300_boot_order_reports_enabled_competing_network_option() {
+        let options = boot_options(Some(true), Some(true), Some(true));
+        let diffs = gb300_boot_order_diffs(&boot_order(&["Boot0001"]), &options);
+
+        assert_eq!(diffs.len(), 1);
+        assert_diff(
+            &diffs[0],
+            "BootOptions/Boot0002/BootOptionEnabled",
+            "false",
+            "true",
+        );
+    }
+
+    #[test]
+    fn gb300_boot_order_reports_missing_enablement_values() {
+        for (target_enabled, other_network_enabled, expected_reference, expected_value) in [
+            (None, Some(false), "Boot0001", "true"),
+            (Some(true), None, "Boot0002", "false"),
+        ] {
+            let options = boot_options(target_enabled, other_network_enabled, Some(true));
+            let diffs = gb300_boot_order_diffs(&boot_order(&["Boot0001"]), &options);
+
+            assert_eq!(diffs.len(), 1);
+            assert_diff(
+                &diffs[0],
+                &format!("BootOptions/{expected_reference}/BootOptionEnabled"),
+                expected_value,
+                "_missing_",
+            );
+        }
+    }
+
+    #[test]
+    fn gb300_boot_order_reports_target_not_first() {
+        let options = boot_options(Some(true), Some(false), Some(true));
+        let diffs = gb300_boot_order_diffs(&boot_order(&["Boot0003", "Boot0001"]), &options);
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].key, "boot_first");
+        assert_eq!(diffs[0].expected, TARGET_DISPLAY_NAME);
+        assert_eq!(diffs[0].actual, "UEFI Disk");
+    }
+
+    #[test]
+    fn gb300_boot_order_compares_boot_option_references() {
+        let mut options = boot_options(Some(true), Some(false), Some(true));
+        options[1].display_name = TARGET_DISPLAY_NAME.to_string();
+        let diffs = gb300_boot_order_diffs(&boot_order(&["Boot0002", "Boot0001"]), &options);
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].key, "boot_first");
+    }
+
+    #[test]
+    fn gb300_boot_order_ignores_non_network_enablement() {
+        let options = boot_options(Some(true), Some(false), None);
+        let diffs = gb300_boot_order_diffs(&boot_order(&["Boot0001"]), &options);
+
+        assert!(diffs.is_empty());
+    }
+
+    #[test]
+    fn other_ami_vendors_ignore_network_option_enablement() {
+        let options = boot_options(Some(false), Some(true), Some(true));
+        let order = boot_order(&["Boot0001"]);
+
+        for vendor in [RedfishVendor::AMI, RedfishVendor::LenovoAMI] {
+            let diffs = compare_boot_order(Some(vendor), &order, &options, BOOT_INTERFACE_MAC);
+            assert!(diffs.is_empty(), "{vendor} unexpectedly reported a diff");
+        }
+    }
 
     #[test]
     fn update_parameters_serializes_to_pascal_case_targets() {

--- a/src/model/boot.rs
+++ b/src/model/boot.rs
@@ -155,3 +155,24 @@ pub fn boot_order_entry_reference(entry: &str) -> &str {
         .split_once(": ")
         .map_or(entry, |(reference, _)| reference)
 }
+
+/// Moves the entry for `target_reference` to the front of `boot_order` while
+/// preserving the exact string reported by the BMC.
+///
+/// Returns `false` when the reference is not present.
+pub fn promote_boot_order_entry_first(
+    boot_order: &mut Vec<String>,
+    target_reference: &str,
+) -> bool {
+    let Some(target_index) = boot_order
+        .iter()
+        .position(|entry| boot_order_entry_reference(entry) == target_reference)
+    else {
+        return false;
+    };
+
+    let target_entry = boot_order.remove(target_index);
+    boot_order.retain(|entry| boot_order_entry_reference(entry) != target_reference);
+    boot_order.insert(0, target_entry);
+    true
+}

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -13,7 +13,7 @@ use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateSe
 use crate::Boot::UefiHttp;
 use crate::{
     model::{
-        boot::{BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
+        boot::{self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
         chassis::{Assembly, NetworkAdapter},
         sel::{LogEntry, LogEntryCollection},
         service_root::ServiceRoot,
@@ -26,6 +26,68 @@ use crate::{
 use crate::{EnabledDisabled, JobState, MachineSetupDiff, MachineSetupStatus, RoleId};
 
 const UEFI_PASSWORD_NAME: &str = "AdminPassword";
+
+fn secure_boot_diffs(secure_boot_enabled: bool) -> Vec<MachineSetupDiff> {
+    let mut diffs = Vec::new();
+
+    if secure_boot_enabled {
+        diffs.push(MachineSetupDiff {
+            key: "SecureBoot".to_string(),
+            expected: "false".to_string(),
+            actual: "true".to_string(),
+        });
+    }
+
+    diffs
+}
+
+fn dpu_http_boot_option_name(boot_interface_mac: &str) -> String {
+    let mac = boot_interface_mac.replace(':', "").to_uppercase();
+    format!("{} (MAC:{mac})", BootOptionName::Http.to_string())
+}
+
+fn find_dpu_http_boot_option<'a>(
+    boot_options: &'a [BootOption],
+    boot_interface_mac: &str,
+) -> Option<&'a BootOption> {
+    let expected = dpu_http_boot_option_name(boot_interface_mac);
+    boot_options
+        .iter()
+        .find(|option| option.display_name.eq_ignore_ascii_case(&expected))
+}
+
+fn compare_boot_order(
+    boot_order: &[String],
+    boot_options: &[BootOption],
+    boot_interface_mac: &str,
+) -> Vec<MachineSetupDiff> {
+    let target = find_dpu_http_boot_option(boot_options, boot_interface_mac);
+    let actual_first_reference = boot_order
+        .first()
+        .map(|entry| boot::boot_order_entry_reference(entry));
+    if target
+        .is_some_and(|option| actual_first_reference == Some(option.boot_option_reference.as_str()))
+    {
+        return Vec::new();
+    }
+
+    let expected = target
+        .map(|option| option.display_name.clone())
+        .unwrap_or_else(|| "Not found".to_string());
+    let actual = actual_first_reference
+        .and_then(|reference| {
+            boot_options
+                .iter()
+                .find(|option| option.boot_option_reference == reference)
+        })
+        .map(|option| option.display_name.clone())
+        .unwrap_or_else(|| "Not found".to_string());
+    vec![MachineSetupDiff {
+        key: "boot_first".to_string(),
+        expected,
+        actual,
+    }]
+}
 
 pub struct Bmc {
     s: RedfishStandard,
@@ -245,18 +307,14 @@ impl Redfish for Bmc {
 
     fn machine_setup_status<'a>(
         &'a self,
-        _boot_interface: Option<crate::BootInterfaceRef<'a>>,
+        boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
         Box::pin(async move {
-            let mut diffs = vec![];
-
             let sb = self.get_secure_boot().await?;
-            if sb.secure_boot_enable.unwrap_or(false) {
-                diffs.push(MachineSetupDiff {
-                    key: "SecureBoot".to_string(),
-                    expected: "false".to_string(),
-                    actual: "true".to_string(),
-                });
+            let mut diffs = secure_boot_diffs(sb.secure_boot_enable.unwrap_or(false));
+            if let Some(boot_interface) = boot_interface {
+                let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+                diffs.extend(self.boot_order_diffs(&mac).await?);
             }
 
             Ok(MachineSetupStatus {
@@ -747,21 +805,30 @@ impl Redfish for Bmc {
 
     fn set_boot_order_dpu_first<'a>(
         &'a self,
-        _boot_interface: crate::BootInterfaceRef<'a>,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move {
-            // TODO: If a mac_address is given
-            // read all the boot options
-            // look for "DisplayName" of "UEFI HTTPv4 (MAC:58A2E1BBB10F)"
-            // get it's Id (e.g. "Boot0020")
-            // Set that first
-            //
-            // If no MAC is given there no way for us to locate the Bluefield on GH200
-            // because it doens't have NetworkAdapters or PCIeDevices trees
-
-            Err(RedfishError::NotSupported(
-                "set_dpu_first_boot_order".to_string(),
-            ))
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            let (system, boot_options) = self.get_system_and_boot_options().await?;
+            let target = find_dpu_http_boot_option(&boot_options, &mac).ok_or_else(|| {
+                RedfishError::MissingBootOption(format!(
+                    "No boot option matching {}",
+                    dpu_http_boot_option_name(&mac)
+                ))
+            })?;
+            let mut boot_order = system.boot.boot_order;
+            let target_reference = &target.boot_option_reference;
+            if boot_order
+                .first()
+                .is_some_and(|entry| boot::boot_order_entry_reference(entry) == target_reference)
+            {
+                return Ok(None);
+            }
+            if !boot::promote_boot_order_entry_first(&mut boot_order, target_reference) {
+                boot_order.insert(0, target_reference.clone());
+            }
+            self.change_boot_order(boot_order).await?;
+            Ok(None)
         })
     }
 
@@ -889,12 +956,11 @@ impl Redfish for Bmc {
 
     fn is_boot_order_setup<'a>(
         &'a self,
-        _boot_interface: crate::BootInterfaceRef<'a>,
+        boot_interface: crate::BootInterfaceRef<'a>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
-            Err(RedfishError::NotSupported(
-                "not populated for GH200".to_string(),
-            ))
+            let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
+            Ok(self.boot_order_diffs(&mac).await?.is_empty())
         })
     }
 
@@ -999,9 +1065,8 @@ impl Redfish for Bmc {
         _boot_interface: Option<crate::BootInterfaceRef<'a>>,
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
-            Err(RedfishError::NotSupported(
-                "not populated for GH200".to_string(),
-            ))
+            let secure_boot = self.get_secure_boot().await?;
+            Ok(secure_boot_diffs(secure_boot.secure_boot_enable.unwrap_or(false)).is_empty())
         })
     }
 
@@ -1033,6 +1098,39 @@ impl Redfish for Bmc {
 }
 
 impl Bmc {
+    async fn get_system_and_boot_options(
+        &self,
+    ) -> Result<(ComputerSystem, Vec<BootOption>), RedfishError> {
+        let system = self.s.get_system().await?;
+        let boot_options_id =
+            system
+                .boot
+                .boot_options
+                .clone()
+                .ok_or_else(|| RedfishError::MissingKey {
+                    key: "boot.boot_options".to_string(),
+                    url: system.odata.odata_id.clone(),
+                })?;
+        let boot_options = self
+            .get_collection(boot_options_id)
+            .await
+            .and_then(|collection| collection.try_get::<BootOption>())?
+            .members;
+        Ok((system, boot_options))
+    }
+
+    async fn boot_order_diffs(
+        &self,
+        boot_interface_mac: &str,
+    ) -> Result<Vec<MachineSetupDiff>, RedfishError> {
+        let (system, boot_options) = self.get_system_and_boot_options().await?;
+        Ok(compare_boot_order(
+            &system.boot.boot_order,
+            &boot_options,
+            boot_interface_mac,
+        ))
+    }
+
     // name: The name of the device you want to make the first boot choice.
     async fn set_boot_order(&self, name: BootOptionName) -> Result<(), RedfishError> {
         let boot_array = self
@@ -1080,5 +1178,70 @@ impl Bmc {
             self.s.client.get(&url).await?;
         let log_entries = log_entry_collection.members;
         Ok(log_entries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn setup_without_boot_target_preserves_secure_boot_status() {
+        assert!(secure_boot_diffs(false).is_empty());
+
+        let diffs = secure_boot_diffs(true);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].key, "SecureBoot");
+    }
+
+    fn boot_option(reference: &str, display_name: &str) -> BootOption {
+        BootOption {
+            odata: Default::default(),
+            alias: None,
+            description: None,
+            boot_option_enabled: Some(true),
+            boot_option_reference: reference.to_string(),
+            display_name: display_name.to_string(),
+            id: reference.to_string(),
+            name: display_name.to_string(),
+            uefi_device_path: None,
+        }
+    }
+
+    #[test]
+    fn exact_http_boot_option_is_verified_by_mac_and_reference() {
+        let target_name = "UEFI HTTPv4 (MAC:58A2E1BBB10F)";
+        let options = vec![
+            boot_option("Boot0001", "UEFI Hard Drive"),
+            boot_option("Boot0020", target_name),
+        ];
+
+        let diffs = compare_boot_order(
+            &["Boot0020: Selected network adapter".to_string()],
+            &options,
+            "58:a2:e1:bb:b1:0f",
+        );
+
+        assert!(diffs.is_empty());
+    }
+
+    #[test]
+    fn different_first_boot_option_is_reported() {
+        let target_name = "UEFI HTTPv4 (MAC:58A2E1BBB10F)";
+        let options = vec![
+            boot_option("Boot0001", "UEFI Hard Drive"),
+            boot_option("Boot0020", target_name),
+        ];
+
+        let diffs = compare_boot_order(
+            &["Boot0001".to_string(), "Boot0020".to_string()],
+            &options,
+            "58:A2:E1:BB:B1:0F",
+        );
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].key, "boot_first");
+        assert_eq!(diffs[0].expected, target_name);
+        assert_eq!(diffs[0].actual, "UEFI Hard Drive");
     }
 }

--- a/src/nvidia_vera_rubin.rs
+++ b/src/nvidia_vera_rubin.rs
@@ -106,16 +106,13 @@ fn promote_boot_order_entry_first(
     boot_order: &mut Vec<String>,
     target_reference: &str,
 ) -> Result<(), RedfishError> {
-    let target_index = boot_order
-        .iter()
-        .position(|entry| boot_order_entry_reference(entry) == target_reference)
-        .ok_or_else(|| RedfishError::GenericError {
+    if crate::model::boot::promote_boot_order_entry_first(boot_order, target_reference) {
+        Ok(())
+    } else {
+        Err(RedfishError::GenericError {
             error: format!("Boot option {target_reference} is not present in BootOrder"),
-        })?;
-    // Preserve the exact entry returned by Vera Rubin firmware.
-    let target_entry = boot_order.remove(target_index);
-    boot_order.insert(0, target_entry);
-    Ok(())
+        })
+    }
 }
 
 impl BootOptionMatchField {

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -74,6 +74,93 @@ const MIN_BMC_FW_IPMI_HOST_IFACE: &str = "01.05.01";
 const HARD_DISK: &str = "UEFI Hard Disk";
 const NETWORK: &str = "UEFI Network";
 
+fn usable_standard_boot_order(boot_order: Vec<String>) -> Option<Vec<String>> {
+    (!boot_order.is_empty()).then_some(boot_order)
+}
+
+fn is_supported_uefi_http_boot_option(display_name: &str) -> bool {
+    display_name.contains(MELLANOX_UEFI_HTTP_IPV4) || display_name.contains(NVIDIA_UEFI_HTTP_IPV4)
+}
+
+fn http_boot_option_matches_mac(display_name: &str, boot_interface_mac: &str) -> bool {
+    is_supported_uefi_http_boot_option(display_name)
+        && display_name
+            .to_ascii_uppercase()
+            .contains(&boot_interface_mac.to_ascii_uppercase())
+}
+
+fn standard_boot_order_diff(
+    boot_order: &[String],
+    boot_options: &[BootOption],
+    boot_interface_mac: &str,
+) -> Option<MachineSetupDiff> {
+    let target = boot_options
+        .iter()
+        .find(|option| http_boot_option_matches_mac(&option.display_name, boot_interface_mac));
+    let actual_reference = boot_order
+        .first()
+        .map(|entry| boot::boot_order_entry_reference(entry));
+
+    if target.is_some_and(|option| actual_reference == Some(option.boot_option_reference.as_str()))
+    {
+        return None;
+    }
+
+    let expected = target
+        .map(|option| option.display_name.clone())
+        .unwrap_or_else(|| "Not found".to_string());
+    let actual = actual_reference
+        .and_then(|reference| {
+            boot_options
+                .iter()
+                .find(|option| option.boot_option_reference == reference)
+        })
+        .map(|option| option.display_name.clone())
+        .unwrap_or_else(|| "Not found".to_string());
+
+    Some(MachineSetupDiff {
+        key: "boot_first".to_string(),
+        expected,
+        actual,
+    })
+}
+
+fn fixed_boot_order_diff(
+    fixed_boot_order: &[String],
+    uefi_network: &[String],
+    boot_interface_mac: &str,
+) -> Option<MachineSetupDiff> {
+    let expected = uefi_network
+        .iter()
+        .find(|entry| http_boot_option_matches_mac(entry, boot_interface_mac))
+        .cloned();
+    let actual = fixed_boot_order.first().map(|entry| {
+        let network_category = entry
+            .strip_prefix(NETWORK)
+            .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with(':'));
+        if network_category {
+            uefi_network
+                .first()
+                .cloned()
+                .unwrap_or_else(|| entry.clone())
+        } else if let Some((_, option)) = entry.split_once(':') {
+            option.trim().to_string()
+        } else {
+            entry.clone()
+        }
+    });
+
+    if expected.is_some() && expected == actual {
+        return None;
+    }
+
+    Some(MachineSetupDiff {
+        key: "boot_first".to_string(),
+        expected: expected.unwrap_or_else(|| "Not found".to_string()),
+        actual: actual.unwrap_or_else(|| "Not found".to_string()),
+    })
+}
+
 pub struct Bmc {
     s: RedfishStandard,
 }
@@ -270,14 +357,8 @@ impl Redfish for Bmc {
 
             // Check the first boot option
             if let Some(mac) = boot_interface_mac {
-                let (expected, actual) =
-                    self.get_expected_and_actual_first_boot_option(mac).await?;
-                if expected.is_none() || expected != actual {
-                    diffs.push(MachineSetupDiff {
-                        key: "boot_first".to_string(),
-                        expected: expected.unwrap_or_else(|| "Not found".to_string()),
-                        actual: actual.unwrap_or_else(|| "Not found".to_string()),
-                    });
+                if let Some(diff) = self.boot_order_diff(mac).await? {
+                    diffs.push(diff);
                 }
             }
 
@@ -904,8 +985,12 @@ impl Redfish for Bmc {
         Box::pin(async move {
             let mac_address = crate::resolve_boot_interface_mac(self, boot_interface).await?;
             let mac_address = mac_address.as_str();
-            match self.set_mellanox_first(mac_address).await {
-                Ok(_) => return Ok(None),
+            match self
+                .try_set_standard_boot_order_dpu_first(mac_address)
+                .await
+            {
+                Ok(true) => return Ok(None),
+                Ok(false) => {}
                 Err(RedfishError::HTTPErrorCode {
                     status_code,
                     response_body,
@@ -920,7 +1005,7 @@ impl Redfish for Bmc {
                 Err(e) => return Err(e),
             }
 
-            // Some supermicro models don't support the set_mellanox_first method, so we fall back to this method
+            // Some Supermicro models only expose the OEM fixed boot order.
             let mut fbo = self.get_boot_order().await?;
 
             // The network name is not consistent because it includes the interface name.
@@ -950,12 +1035,7 @@ impl Redfish for Bmc {
             let Some(pos) = fbo
                 .uefi_network
                 .iter()
-                .position(|s| s.contains("UEFI HTTP IPv4 Mellanox") && s.contains(mac_address))
-                .or_else(|| {
-                    fbo.uefi_network.iter().position(|s| {
-                        s.contains("UEFI HTTP IPv4 Nvidia") && s.contains(mac_address)
-                    })
-                })
+                .position(|entry| http_boot_option_matches_mac(entry, mac_address))
             else {
                 return Err(RedfishError::NotSupported(
                 format!("No match for Mellanox/Nvidia HTTP adapter with MAC address {} in network boot order", mac_address)
@@ -1111,8 +1191,7 @@ impl Redfish for Bmc {
     ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
         Box::pin(async move {
             let mac = crate::resolve_boot_interface_mac(self, boot_interface).await?;
-            let (expected, actual) = self.get_expected_and_actual_first_boot_option(&mac).await?;
-            Ok(expected.is_some() && expected == actual)
+            Ok(self.boot_order_diff(&mac).await?.is_none())
         })
     }
 
@@ -1231,37 +1310,29 @@ impl Bmc {
         Ok(diffs)
     }
 
-    async fn get_expected_and_actual_first_boot_option(
+    async fn boot_order_diff(
         &self,
         boot_interface_mac: &str,
-    ) -> Result<(Option<String>, Option<String>), RedfishError> {
+    ) -> Result<Option<MachineSetupDiff>, RedfishError> {
         // Try using standard BootOptions first
         match self.s.get_boot_options().await {
             Ok(all) => {
-                // Get actual first boot option
-                let actual_first_boot_option = if let Some(first) = all.members.first() {
-                    let id = first.odata_id_get()?;
-                    Some(self.s.get_boot_option(id).await?.display_name)
-                } else {
-                    None
-                };
-
-                // Find expected boot option
-                let mut expected_first_boot_option = None;
-                for b in &all.members {
-                    let id = b.odata_id_get()?;
-                    let boot_option = self.s.get_boot_option(id).await?;
-
-                    if (boot_option.display_name.contains(MELLANOX_UEFI_HTTP_IPV4)
-                        || boot_option.display_name.contains(NVIDIA_UEFI_HTTP_IPV4))
-                        && boot_option.display_name.contains(boot_interface_mac)
-                    {
-                        expected_first_boot_option = Some(boot_option.display_name);
-                        break;
-                    }
+                let system = self.s.get_system().await?;
+                if system.boot.boot_order.is_empty() {
+                    return self.load_fixed_boot_order_diff(boot_interface_mac).await;
                 }
 
-                Ok((expected_first_boot_option, actual_first_boot_option))
+                let mut boot_options = Vec::with_capacity(all.members.len());
+                for member in &all.members {
+                    let id = member.odata_id_get()?;
+                    boot_options.push(self.s.get_boot_option(id).await?);
+                }
+
+                Ok(standard_boot_order_diff(
+                    &system.boot.boot_order,
+                    &boot_options,
+                    boot_interface_mac,
+                ))
             }
             Err(RedfishError::HTTPErrorCode {
                 status_code,
@@ -1272,29 +1343,22 @@ impl Bmc {
                 && response_body.contains("BootOrder") =>
             {
                 // Fall back to FixedBootOrder for platforms that don't support standard BootOptions
-                let fbo = self.get_boot_order().await?;
-
-                // Get actual first boot option (strip prefix like "UEFI Network:", "UEFI Hard Disk:", etc.)
-                let actual_first_boot_option = fbo.fixed_boot_order.first().and_then(|entry| {
-                    // Find the first colon and take everything after it
-                    entry.find(':').map(|idx| entry[idx + 1..].to_string())
-                });
-
-                // Find expected boot option in UEFINetwork list
-                let expected_first_boot_option = fbo
-                    .uefi_network
-                    .iter()
-                    .find(|entry| {
-                        (entry.contains(MELLANOX_UEFI_HTTP_IPV4)
-                            || entry.contains(NVIDIA_UEFI_HTTP_IPV4))
-                            && entry.contains(boot_interface_mac)
-                    })
-                    .cloned();
-
-                Ok((expected_first_boot_option, actual_first_boot_option))
+                self.load_fixed_boot_order_diff(boot_interface_mac).await
             }
             Err(e) => Err(e),
         }
+    }
+
+    async fn load_fixed_boot_order_diff(
+        &self,
+        boot_interface_mac: &str,
+    ) -> Result<Option<MachineSetupDiff>, RedfishError> {
+        let fbo = self.get_boot_order().await?;
+        Ok(fixed_boot_order_diff(
+            &fbo.fixed_boot_order,
+            &fbo.uefi_network,
+            boot_interface_mac,
+        ))
     }
 
     async fn machine_setup_attrs(&self) -> Result<Vec<(String, serde_json::Value)>, RedfishError> {
@@ -1601,10 +1665,11 @@ impl Bmc {
             let Some(pos) = fbo
                 .uefi_network
                 .iter()
-                .position(|s| s.contains("UEFI HTTP IPv4 Mellanox"))
+                .position(|entry| is_supported_uefi_http_boot_option(entry))
             else {
                 return Err(RedfishError::NotSupported(
-                    "No match for 'UEFI HTTP IPv4 Mellanox' in network boot order".to_string(),
+                    "No match for a Mellanox/NVIDIA UEFI HTTP IPv4 adapter in network boot order"
+                        .to_string(),
                 ));
             };
             fbo.uefi_network.swap(0, pos);
@@ -1634,40 +1699,50 @@ impl Bmc {
         Ok(body)
     }
 
-    /// Set the DPU to be our first netboot device.
+    /// Try to select the DPU through the standard Redfish boot order.
     ///
-    /// Callers should usually ignore the error and continue. The HTTP adapter
-    /// will only appear after IPv4HTTPSupport bios setting is enabled and the host rebooted.
-    /// If the Mellanox adapter is not first everything still works, but boot takes a little longer
-    /// because it tries the other adapters too.
-    async fn set_mellanox_first(&self, boot_interface: &str) -> Result<(), RedfishError> {
-        let mut with_name_match = None; // the ID of the option matching with_name
-        let mut ordered = Vec::new(); // the final boot options
+    /// An empty standard boot order selects the OEM fixed-order fallback.
+    async fn try_set_standard_boot_order_dpu_first(
+        &self,
+        boot_interface: &str,
+    ) -> Result<bool, RedfishError> {
+        let system = self.s.get_system().await?;
+        let Some(mut boot_order) = usable_standard_boot_order(system.boot.boot_order) else {
+            return Ok(false);
+        };
+
         let all = self.s.get_boot_options().await?;
+        let mut target_reference = None;
         for b in all.members {
             let id = b.odata_id_get()?;
             let boot_option = self.s.get_boot_option(id).await?;
 
-            if (boot_option.display_name.contains(MELLANOX_UEFI_HTTP_IPV4)
-                || boot_option.display_name.contains(NVIDIA_UEFI_HTTP_IPV4))
-                && boot_option.display_name.contains(boot_interface)
-            {
+            if http_boot_option_matches_mac(&boot_option.display_name, boot_interface) {
                 // Here are the patterns we have seen so far:
                 // UEFI HTTP IPv4 Mellanox Network Adapter - A0:88:C2:EA:84:D0(MAC:A088C2EA84D0)
                 // UEFI HTTP IPv4 Nvidia Network Adapter - C4:70:BD:F0:40:AA - C470BDF040AA"
-                with_name_match = Some(boot_option.id);
-            } else {
-                ordered.push(boot_option.id);
+                target_reference = Some(boot_option.boot_option_reference);
+                break;
             }
         }
-        if with_name_match.is_none() {
+        let Some(target_reference) = target_reference else {
             // This happens if IPv4HTTPSupport#00F7 is disabled in the bios
             return Err(RedfishError::NotSupported(
                 "No match for Mellanox HTTP adapter boot".to_string(),
             ));
+        };
+
+        if boot_order
+            .first()
+            .is_some_and(|entry| boot::boot_order_entry_reference(entry) == target_reference)
+        {
+            return Ok(true);
         }
-        ordered.insert(0, with_name_match.unwrap());
-        self.change_boot_order(ordered).await
+        if !boot::promote_boot_order_entry_first(&mut boot_order, &target_reference) {
+            boot_order.insert(0, target_reference);
+        }
+        self.change_boot_order(boot_order).await?;
+        Ok(true)
     }
 
     // BIOS attribute names by their canonical name.
@@ -1801,6 +1876,124 @@ impl UpdateParameters {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn boot_option(reference: &str, display_name: &str) -> BootOption {
+        BootOption {
+            odata: Default::default(),
+            alias: None,
+            description: None,
+            boot_option_enabled: Some(true),
+            boot_option_reference: reference.to_string(),
+            display_name: display_name.to_string(),
+            id: reference.to_string(),
+            name: display_name.to_string(),
+            uefi_device_path: None,
+        }
+    }
+
+    #[test]
+    fn standard_boot_verification_uses_system_boot_order_not_collection_order() {
+        let target = format!("{NVIDIA_UEFI_HTTP_IPV4} - B8:E9:24:17:6D:72 (MAC:B8E924176D72)");
+        let disk = "UEFI Hard Disk";
+        let options = vec![
+            boot_option("Boot0001", &target),
+            boot_option("Boot0002", disk),
+        ];
+
+        let diff = standard_boot_order_diff(
+            &["Boot0002".to_string(), "Boot0001".to_string()],
+            &options,
+            "b8:e9:24:17:6d:72",
+        )
+        .expect("disk is first");
+
+        assert_eq!(diff.expected, target);
+        assert_eq!(diff.actual, disk);
+    }
+
+    #[test]
+    fn supported_uefi_http_boot_options_include_mellanox_and_nvidia_names() {
+        for display_name in [MELLANOX_UEFI_HTTP_IPV4, NVIDIA_UEFI_HTTP_IPV4] {
+            assert!(is_supported_uefi_http_boot_option(display_name));
+        }
+        assert!(!is_supported_uefi_http_boot_option(
+            "UEFI HTTP IPv4 Intel Network Adapter"
+        ));
+    }
+
+    #[test]
+    fn standard_boot_verification_resolves_decorated_boot_order_reference() {
+        let target = format!("{MELLANOX_UEFI_HTTP_IPV4} - B8:E9:24:17:6D:72 (MAC:B8E924176D72)");
+        let options = vec![
+            boot_option("Boot0002", "UEFI Hard Disk"),
+            boot_option("Boot0001", &target),
+        ];
+
+        let diff = standard_boot_order_diff(
+            &["Boot0001: Selected network adapter".to_string()],
+            &options,
+            "B8:E9:24:17:6D:72",
+        );
+
+        assert!(diff.is_none());
+    }
+
+    #[test]
+    fn standard_boot_verification_compares_references_not_display_names() {
+        let target = format!("{MELLANOX_UEFI_HTTP_IPV4} - B8:E9:24:17:6D:72 (MAC:B8E924176D72)");
+        let options = vec![
+            boot_option("Boot0001", &target),
+            boot_option("Boot0002", &target),
+        ];
+
+        let diff = standard_boot_order_diff(
+            &["Boot0002".to_string(), "Boot0001".to_string()],
+            &options,
+            "B8:E9:24:17:6D:72",
+        );
+
+        assert!(diff.is_some());
+    }
+
+    #[test]
+    fn fixed_boot_verification_resolves_network_category_and_prefixed_entry() {
+        let target = format!("{NVIDIA_UEFI_HTTP_IPV4} - B8:E9:24:17:6D:72 (MAC:B8E924176D72)");
+        let uefi_network = vec![target.clone()];
+
+        for fixed_order in [
+            vec![NETWORK.to_string()],
+            vec![format!("{NETWORK}:{target}")],
+        ] {
+            let diff = fixed_boot_order_diff(&fixed_order, &uefi_network, "b8:e9:24:17:6d:72");
+            assert!(diff.is_none(), "unexpected diff for {fixed_order:?}");
+        }
+    }
+
+    #[test]
+    fn empty_standard_boot_order_is_not_usable() {
+        assert!(usable_standard_boot_order(Vec::new()).is_none());
+    }
+
+    #[test]
+    fn fixed_boot_verification_uses_selected_network_device_not_category_suffix() {
+        let target = format!("{NVIDIA_UEFI_HTTP_IPV4} - B8:E9:24:17:6D:72 (MAC:B8E924176D72)");
+        let other = format!("{NVIDIA_UEFI_HTTP_IPV4} - B8:E9:24:17:6D:73 (MAC:B8E924176D73)");
+
+        let diff = fixed_boot_order_diff(
+            &[format!("{NETWORK}:{other}")],
+            &[target.clone(), other.clone()],
+            "b8:e9:24:17:6d:72",
+        );
+        assert!(diff.is_none());
+
+        let diff = fixed_boot_order_diff(
+            &[format!("{NETWORK}:{target}")],
+            &[other.clone(), target],
+            "b8:e9:24:17:6d:72",
+        )
+        .expect("a different network device is selected");
+        assert_eq!(diff.actual, other);
+    }
 
     #[test]
     fn identifies_mgx_c2_processor_modules() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -491,6 +491,21 @@ async fn run_integration_test(
         redfish.boot_first(libredfish::Boot::HardDisk).await?;
     }
 
+    if vendor_dir == "nvidia_gh200" {
+        let target = libredfish::BootInterfaceRef::Mac(mac_address::MacAddress::new([
+            0x58, 0xA2, 0xE1, 0xBB, 0xB1, 0x0F,
+        ]));
+        assert!(redfish.is_bios_setup(Some(target)).await?);
+        assert!(!redfish.is_boot_order_setup(target).await?);
+        assert!(redfish
+            .machine_setup_status(Some(target))
+            .await?
+            .diffs
+            .iter()
+            .any(|diff| diff.key == "boot_first"));
+        redfish.set_boot_order_dpu_first(target).await?;
+    }
+
     // Exercise set_boot_override on vendors that support the bare (no URI)
     // override variant via the standard Redfish Boot block PATCH. The mockup
     // doesn't validate the PATCH body -- this just verifies the call path


### PR DESCRIPTION
LibRedfish now applies and verifies the same exact boot-interface target across the AMI, GH200, and Supermicro implementations.

Previously, some vendor paths could report success for a different network boot option, compare Redfish collection order instead of the active `BootOrder`, or lose vendor-decorated order entries while updating the selected option. That made an observation-driven caller unable to prove that the target it requested was the target the BMC would boot.

This change:

- resolves the exact selected boot option from its MAC/interface pair and uses its `BootOptionReference` consistently for apply and verification;
- preserves decorated AMI/GB300 order entries and the relative order of non-target options;
- makes GH200 promote and verify the requested `UEFI HTTPv4` option while retaining the existing no-target secure-boot behavior;
- makes generic Supermicro recognize both Mellanox- and NVIDIA-branded HTTP adapters and prefer standard `ComputerSystem.Boot.BootOrder`, while using `FixedBootOrder` when the standard order is unavailable or empty;
- keeps Lenovo GB300 apply and status checks on one shared selected-option invariant.

Supermicro GB300 hardware enablement remains separate until that vendor path is validated on hardware.

Fixes #113.

Supports NVIDIA/infra-controller#4193.

## Testing

- `cargo test` — 110 unit tests and 13 integration tests passed; the existing Vera Rubin hardware test remains ignored.
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
