### PR TITLE
feat: support fetching BMC event logs on GB200

### DIFF
--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -498,7 +498,13 @@ impl Redfish for Bmc {
         &'a self,
         from: Option<chrono::DateTime<chrono::Utc>>,
     ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_bmc_event_log(from).await })
+        Box::pin(async move {
+            let url = format!(
+                "Systems/{}/LogServices/EventLog/Entries",
+                self.s.system_id()
+            );
+            self.s.fetch_bmc_event_log(url, from).await
+        })
     }
 
     fn get_drives_metrics<'a>(


### PR DESCRIPTION
Implements `get_bmc_event_log` for GB200s using the existing `fetch_bmc_event_log` helper, which filters server-side via `$filter`.

Tested against a live GB200 BMC, rebooted the host and confirmed the new entries come back filtered:
```
curl -sku 'user:pass' "https://<ip>/redfish/v1/Systems/System_0/LogServices/EventLog/Entries \
 $filter=Created%20ge%20%272026-07-30T14:00:00Z%27"
```

