### PR TITLE
feat: expose Lenovo network adapter port MAC addresses

### DIFF
--- a/src/model/oem/lenovo.rs
+++ b/src/model/oem/lenovo.rs
@@ -52,6 +52,12 @@ pub struct System {
     pub boot_settings: Option<ODataId>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+pub struct Port {
+    pub physical_port_mac_address: Option<String>,
+}
+
 /* Front Panel USB Port Management mapping from UI to redfish API:
 
  - UI: Host Only Mode

--- a/src/model/oem/mod.rs
+++ b/src/model/oem/mod.rs
@@ -27,3 +27,9 @@ pub struct SystemExtensions {
 pub struct ChassisExtensions {
     pub nvidia: Option<nvidia_openbmc::ChassisExtensions>,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+pub struct PortExtensions {
+    pub lenovo: Option<lenovo::Port>,
+}

--- a/src/model/port.rs
+++ b/src/model/port.rs
@@ -22,7 +22,9 @@
  */
 use serde::{Deserialize, Serialize};
 
-use super::{LinkStatus, ODataLinks};
+use super::oem::PortExtensions;
+use super::{InvalidValueError, LinkStatus, ODataLinks};
+use crate::RedfishError;
 
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
 pub enum LinkNetworkTechnology {
@@ -37,9 +39,9 @@ impl std::fmt::Display for LinkNetworkTechnology {
     }
 }
 
-/// http://redfish.dmtf.org/schemas/v1/NetworkPort.v1_4_1.json
-/// The NetworkPort schema contains an inventory of software components.
-/// This can include Network Device parameters such as current speed, link status, etc.
+/// https://redfish.dmtf.org/schemas/v1/Port.v1_6_0.json
+/// `NetworkPort` contains the physical port information exposed by the
+/// current Redfish `Port` schema.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct NetworkPort {
@@ -50,5 +52,111 @@ pub struct NetworkPort {
     pub name: Option<String>,
     pub link_status: Option<LinkStatus>,
     pub link_network_technology: Option<LinkNetworkTechnology>,
-    pub current_speed_gbps: Option<i32>,
+    pub current_speed_gbps: Option<f64>,
+    pub ethernet: Option<PortEthernet>,
+    pub oem: Option<PortExtensions>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+pub struct PortEthernet {
+    #[serde(default, rename = "AssociatedMACAddresses")]
+    pub associated_mac_addresses: Vec<String>,
+}
+
+impl NetworkPort {
+    /// `mac_addresses` returns the standard port MAC addresses, falling back
+    /// to Lenovo's physical-port address when XCC omits the standard fields.
+    pub fn mac_addresses(&self) -> Result<Vec<mac_address::MacAddress>, RedfishError> {
+        let (field, addresses) = if let Some(standard_addresses) = self
+            .ethernet
+            .as_ref()
+            .map(|ethernet| ethernet.associated_mac_addresses.as_slice())
+            .filter(|addresses| !addresses.is_empty())
+        {
+            ("Ethernet.AssociatedMACAddresses", standard_addresses)
+        } else {
+            (
+                "Oem.Lenovo.PhysicalPortMacAddress",
+                self.oem
+                    .as_ref()
+                    .and_then(|oem| oem.lenovo.as_ref())
+                    .and_then(|lenovo| lenovo.physical_port_mac_address.as_ref())
+                    .map(std::slice::from_ref)
+                    .unwrap_or_default(),
+            )
+        };
+
+        addresses
+            .iter()
+            .map(|address| {
+                address.parse().map_err(|err: mac_address::MacParseError| {
+                    RedfishError::InvalidValue {
+                        url: self
+                            .odata
+                            .as_ref()
+                            .map(|odata| odata.odata_id.clone())
+                            .unwrap_or_else(|| "Port".to_string()),
+                        field: field.to_string(),
+                        err: InvalidValueError(err.to_string()),
+                    }
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NetworkPort;
+
+    #[test]
+    fn mac_addresses_use_standard_port_data_then_lenovo_fallback() {
+        let cases = [
+            (
+                "standard port data takes precedence",
+                r#"{
+                    "Ethernet": {
+                        "AssociatedMACAddresses": ["02:aa:bb:cc:dd:01"]
+                    },
+                    "Oem": {
+                        "Lenovo": {
+                            "PhysicalPortMacAddress": "not-a-mac"
+                        }
+                    }
+                }"#,
+                "02:aa:bb:cc:dd:01",
+            ),
+            (
+                "Lenovo OEM port",
+                r#"{
+                    "Oem": {
+                        "Lenovo": {
+                            "PhysicalPortMacAddress": "02AABBCCDD02"
+                        }
+                    }
+                }"#,
+                "02:aa:bb:cc:dd:02",
+            ),
+        ];
+
+        for (name, json, expected) in cases {
+            let port: NetworkPort = serde_json::from_str(json).unwrap();
+            let addresses = port.mac_addresses().unwrap();
+            assert_eq!(
+                addresses,
+                vec![expected.parse().unwrap()],
+                "unexpected addresses for {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn current_speed_accepts_redfish_number() {
+        let json = include_str!(
+            "../../tests/mockups/hpe/redfish/v1/Chassis/1/NetworkAdapters/DE084000/Ports/0/index.json"
+        );
+        let port: NetworkPort = serde_json::from_str(json).unwrap();
+        assert_eq!(port.current_speed_gbps, Some(100.0));
+    }
 }

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -800,19 +800,32 @@ impl Redfish for RedfishStandard {
 
     fn get_ports<'a>(
         &'a self,
-        _chassis_id: &'a str,
-        _network_adapter: &'a str,
+        chassis_id: &'a str,
+        network_adapter: &'a str,
     ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { Err(RedfishError::NotSupported("get_ports".to_string())) })
+        Box::pin(async move {
+            let url = format!(
+                "Chassis/{}/NetworkAdapters/{}/Ports",
+                chassis_id, network_adapter
+            );
+            self.get_members(&url).await
+        })
     }
 
     fn get_port<'a>(
         &'a self,
-        _chassis_id: &'a str,
-        _network_adapter: &'a str,
-        _id: &'a str,
+        chassis_id: &'a str,
+        network_adapter: &'a str,
+        id: &'a str,
     ) -> crate::RedfishFuture<'a, Result<NetworkPort, RedfishError>> {
-        Box::pin(async move { Err(RedfishError::NotSupported("get_port".to_string())) })
+        Box::pin(async move {
+            let url = format!(
+                "Chassis/{}/NetworkAdapters/{}/Ports/{}",
+                chassis_id, network_adapter, id
+            );
+            let (_status_code, body) = self.client.get(&url).await?;
+            Ok(body)
+        })
     }
 
     fn change_uefi_password<'a>(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -374,6 +374,7 @@ async fn run_integration_test(
 
     let chassis = redfish.get_chassis_all().await?;
     assert!(!chassis.is_empty());
+    let mut tested_lenovo_adapter_ports = vendor_dir != "lenovo";
     for chassis_id in &chassis {
         let _chassis = redfish.get_chassis(chassis_id).await?;
         let Ok(chassis_net_adapters) = redfish.get_chassis_network_adapters(chassis_id).await
@@ -386,6 +387,20 @@ async fn run_integration_test(
                 .await?;
         }
 
+        if vendor_dir == "lenovo" {
+            if let Some(adapter_id) = chassis_net_adapters
+                .iter()
+                .find(|adapter_id| adapter_id.as_str() == "slot-27")
+            {
+                let ports = redfish.get_ports(chassis_id, adapter_id).await?;
+                assert_eq!(ports, ["1", "2", "3", "4"]);
+
+                let port = redfish.get_port(chassis_id, adapter_id, &ports[0]).await?;
+                assert_eq!(port.mac_addresses()?, ["00:62:0b:4c:28:4e".parse()?]);
+                tested_lenovo_adapter_ports = true;
+            }
+        }
+
         if vendor_dir == "hpe" {
             let adapter_ids = redfish.get_base_network_adapters(chassis_id).await?;
             assert!(!adapter_ids.is_empty());
@@ -396,6 +411,7 @@ async fn run_integration_test(
             }
         }
     }
+    assert!(tested_lenovo_adapter_ports);
 
     if vendor_dir != "liteon_powershelf" && vendor_dir != "delta_powershelf" {
         assert_eq!(redfish.get_power_state().await?, libredfish::PowerState::On);


### PR DESCRIPTION
## Summary

- traverse standard network adapter `Ports` collections through `RedfishStandard`
- expose typed MAC addresses from standard port Ethernet data with a Lenovo OEM fallback
- accept numeric `CurrentSpeedGbps` values used by existing Redfish payloads
- cover standard precedence, Lenovo OEM normalization, HPE numeric speed parsing, and Lenovo adapter-port discovery

## Testing

- `cargo fmt --check`
- `cargo clippy --locked --all-targets --all-features --workspace -- -D warnings`
- `cargo build --locked`
- `cargo test --locked`

Fixes #117
