### PR TITLE
fix: dell machine setup TLS status check

### DIFF
--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1593,6 +1593,11 @@ impl Bmc {
             expected_attrs.http_device_1_interface,
             String
         );
+        diff!(
+            "HttpDev1TlsMode",
+            expected_attrs.http_device_1_tls_mode,
+            dell::TlsMode
+        );
 
         let manager_attrs = self.manager_dell_oem_attributes().await?;
         let expected = HashMap::from([

--- a/src/network.rs
+++ b/src/network.rs
@@ -255,7 +255,7 @@ impl RedfishClientPool {
                 .as_ref()
                 .and_then(|swb| swb.links.as_ref())
                 .and_then(|links| links.managed_by.as_ref())
-                .and_then(|mb| mb.get(0))
+                .and_then(|mb| mb.first())
                 .and_then(|d| d.odata_id.trim_matches('/').split('/').next_back())
                 .map(|m| m.to_string());
             manager_id = manager_from_system.unwrap_or(manager_id);

--- a/src/network.rs
+++ b/src/network.rs
@@ -211,9 +211,12 @@ impl RedfishClientPool {
         };
 
         let managers = s.get_managers().await?;
-        let mut manager_id = managers.first().ok_or_else(|| RedfishError::GenericError {
-            error: "No managers found in service root".to_string(),
-        })?.clone();
+        let mut manager_id = managers
+            .first()
+            .ok_or_else(|| RedfishError::GenericError {
+                error: "No managers found in service root".to_string(),
+            })?
+            .clone();
         let chassis = s.get_chassis_all().await?;
 
         // Delta power shelves expose no `/Systems` resource (a real query 404s)
@@ -247,7 +250,6 @@ impl RedfishClientPool {
                 if system_with_bios.is_some() {
                     break;
                 }
-                
             }
             let manager_from_system = system_with_bios
                 .as_ref()
@@ -258,11 +260,12 @@ impl RedfishClientPool {
                 .map(|m| m.to_string());
             manager_id = manager_from_system.unwrap_or(manager_id);
 
-            let system_id = system_with_bios.map(|swb| swb.id.to_owned()).unwrap_or(at_least_one_system_id.to_owned());
+            let system_id = system_with_bios
+                .map(|swb| swb.id.to_owned())
+                .unwrap_or(at_least_one_system_id.to_owned());
 
             // call set_system_id always before calling set_vendor
             s.set_system_id(&system_id)?;
-
         }
 
         s.set_manager_id(&manager_id)?;


### PR DESCRIPTION
This PR validates Dell `HttpDev1TlsMode` during `machine_setup_status()` which was previously missing.

Related issue: https://github.com/NVIDIA/infra-controller/issues/4704
