### PR TITLE
fix: improve PasswordChangeRequired error handling

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -98,7 +98,7 @@ pub enum RedfishError {
     MissingVendor,
 
     #[error("Password change required")]
-    PasswordChangeRequired,
+    PasswordChangeRequired { account_uri: Option<String> },
 
     #[error("Maximum amount of user accounts reached. Delete one to continue.")]
     TooManyUsers,

--- a/src/network.rs
+++ b/src/network.rs
@@ -698,16 +698,18 @@ impl RedfishHttpClient {
                 // If PasswordChangeRequired is in the response, return a PasswordChangeRequired error.
                 if let Ok(err) = serde_json::from_str::<crate::model::error::Error>(&response_body)
                 {
-                    if err
+                    if let Some(password_change_required) = err
                         .error
                         .extended
                         .iter()
                         // TODO(ajf) The actual message ID is specified in DTMF RedFish 9.5.11.2 so we
                         // should properly parse it into a type since the error may come from different
                         // MessageRegistries
-                        .any(|ext| ext.message_id.ends_with("PasswordChangeRequired"))
+                        .find(|ext| ext.message_id.ends_with("PasswordChangeRequired"))
                     {
-                        return Err(RedfishError::PasswordChangeRequired);
+                        return Err(RedfishError::PasswordChangeRequired {
+                            account_uri: password_change_required.message_args.first().cloned(),
+                        });
                     }
                 }
                 // If we can't decode the error JSON, just return the normal HTTPErrorCode. Some

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -157,7 +157,7 @@ async fn test_forbidden_error_handling() -> anyhow::Result<()> {
 
     match redfish.get_chassis_all().await {
         Ok(_) => panic!("Request should have failed with password change required"),
-        Err(libredfish::RedfishError::PasswordChangeRequired) => {} // what we want
+        Err(libredfish::RedfishError::PasswordChangeRequired { .. }) => {} // what we want
         Err(err) => panic!("Unexpected error response: {}", err),
     }
 


### PR DESCRIPTION
This PR:

- Preserves the target manager account URI from `PasswordChangeRequired` extended messages.
- Exposes it as `account_uri: Option<String>` on `RedfishError`.
- Keeps compatibility with BMCs that omit `MessageArgs`.

This allows callers to patch the correct account instead of relying on a hardcoded account ID. Tested manually via compiling nico-admin-cli with this change and verifying the message arg.

Related issue: https://github.com/NVIDIA/infra-controller/issues/4724

