### PR TITLE
feat: patch password anonymously + dell deserialization fix

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -1392,7 +1392,10 @@ impl Redfish for Bmc {
         &'a self,
         servers: &'a [String],
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
+        Box::pin(async move {
+            let servers = &servers[..servers.len().min(2)];
+            self.s.set_manager_ntp_servers(servers).await
+        })
     }
 }
 

--- a/src/model/oem/dell.rs
+++ b/src/model/oem/dell.rs
@@ -99,9 +99,9 @@ pub struct System {
     pub bios_release_date: String,
     pub chassis_service_tag: String,
     pub chassis_system_height_unit: i64,
-    pub estimated_exhaust_temperature_celsius: i64,
+    pub estimated_exhaust_temperature_celsius: Option<i64>,
     #[serde(rename = "EstimatedSystemAirflowCFM")]
-    pub estimated_system_airflow_cfm: i64,
+    pub estimated_system_airflow_cfm: Option<i64>,
     pub express_service_code: String,
     pub fan_rollup_status: Option<String>, // null->None if machine is off
     pub intrusion_rollup_status: String,

--- a/src/network.rs
+++ b/src/network.rs
@@ -378,6 +378,16 @@ impl RedfishHttpClient {
         self.endpoint.user.is_none()
     }
 
+    pub(crate) async fn get_anonymous<T>(&self, api: &str) -> Result<(StatusCode, T), RedfishError>
+    where
+        T: DeserializeOwned + ::std::fmt::Debug,
+    {
+        let mut client = self.clone();
+        client.endpoint.user = None;
+        client.endpoint.password = None;
+        client.get(api).await
+    }
+
     pub async fn get<T>(&self, api: &str) -> Result<(StatusCode, T), RedfishError>
     where
         T: DeserializeOwned + ::std::fmt::Debug,

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -1790,7 +1790,13 @@ impl RedfishStandard {
             self.vendor,
             Some(RedfishVendor::AMI | RedfishVendor::LenovoAMI | RedfishVendor::LenovoGB300)
         ) {
-            self.client.patch_with_if_match(&url, ntp_servers).await
+            match self.client.patch_with_if_match(&url, ntp_servers).await {
+                Err(RedfishError::HTTPErrorCode {
+                    status_code: StatusCode::ACCEPTED,
+                    ..
+                }) => Ok(()),
+                result => result,
+            }
         } else {
             self.client.patch(&url, ntp_servers).await.map(|_resp| ())
         }

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -147,7 +147,21 @@ impl Redfish for RedfishStandard {
             let url = format!("AccountService/Accounts/{}", account_id);
             let mut data = HashMap::new();
             data.insert("Password", new_pass);
-            let service_root = self.get_service_root().await?;
+            // Some BMCs reject authenticated ServiceRoot reads until the
+            // factory password is changed, while still exposing it
+            // anonymously. Prefer that path so password bootstrap can reach
+            // the account PATCH. Fall back to the existing authenticated
+            // lookup for BMCs that protect or omit vendor details there.
+            let service_root = match self.client.get_anonymous::<ServiceRoot>("").await {
+                Ok((_status, service_root))
+                    if service_root
+                        .vendor()
+                        .is_some_and(|vendor| vendor != RedfishVendor::Unknown) =>
+                {
+                    service_root
+                }
+                _ => self.get_service_root().await?,
+            };
             // AMI BMC requires If-Match header for PATCH requests
             if matches!(
                 service_root.vendor(),


### PR DESCRIPTION
This PR:

- Allows Dell `EstimatedExhaustTemperatureCelsius` and `EstimatedSystemAirflowCFM` to be `null` when a machine is powered off, preventing `get_power_state` deserialization failures.
- Preserves the target account URI from `PasswordChangeRequired`.
- Uses anonymous `ServiceRoot` vendor detection during forced password rotation, with authenticated fallback.
- Limits AMI NTP configuration to the first two servers supported by the BMC.
- Accepts asynchronous `202 Accepted` responses specifically for AMI NTP configuration.


Successfully validated on real hardware. 

Addresses issues: 

- https://github.com/NVIDIA/infra-controller/issues/4724
- https://github.com/NVIDIA/infra-controller/issues/4815
- https://github.com/NVIDIA/infra-controller/issues/4816