### PR TITLE
fix: add proper vendor detection for delta powershelves from the service root

### DIFF
--- a/src/model/service_root.rs
+++ b/src/model/service_root.rs
@@ -119,7 +119,7 @@ impl ServiceRoot {
                 _ => RedfishVendor::Supermicro,
             },
             "lite-on technology corp." => RedfishVendor::LiteOnPowerShelf,
-            "delta" => RedfishVendor::DeltaPowerShelf,
+            "delta electronics inc." => RedfishVendor::DeltaPowerShelf,
             _ => RedfishVendor::Unknown,
         })
     }
@@ -188,5 +188,26 @@ mod test {
         };
         assert_eq!(result.vendor().unwrap(), RedfishVendor::VeraRubin);
         assert!(result.is_vera_rubin());
+    }
+
+    #[test]
+    fn test_delta_powershelf_service_root() {
+        // Real Delta power shelves report their full manufacturer string in the
+        // service-root `Vendor` field, not a bare "Delta".
+        let result = ServiceRoot {
+            vendor: Some("Delta Electronics Inc.".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::DeltaPowerShelf);
+    }
+
+    #[test]
+    fn test_delta_powershelf_service_root_case_insensitive() {
+        // Matching is case-insensitive (the vendor string is lowercased first).
+        let result = ServiceRoot {
+            vendor: Some("DELTA ELECTRONICS INC.".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::DeltaPowerShelf);
     }
 }


### PR DESCRIPTION
Delta Service Root Example:
```
{
    "@odata.id": "[/redfish/v1](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1)",
    "@odata.type": "#ServiceRoot.v1_18_0.ServiceRoot",
    "AccountService": {
        "@odata.id": "[/redfish/v1/AccountService](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FAccountService)"
    },
    "CertificateService": {
        "@odata.id": "[/redfish/v1/CertificateService](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FCertificateService)"
    },
    "Chassis": {
        "@odata.id": "[/redfish/v1/Chassis](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FChassis)"
    },
    "EventService": {
        "@odata.id": "[/redfish/v1/EventService](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FEventService)"
    },
    "Id": "RootService",
    "JsonSchemas": {
        "@odata.id": "[/redfish/v1/JsonSchemas](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FJsonSchemas)"
    },
    "Links": {
        "Sessions": {
            "@odata.id": "[/redfish/v1/SessionService/Sessions](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FSessionService%2FSessions)"
        }
    },
    "Managers": {
        "@odata.id": "[/redfish/v1/Managers](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FManagers)"
    },
    "Name": "Root Service",
    "PowerEquipment": {
        "@odata.id": "[/redfish/v1/PowerEquipment](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FPowerEquipment)"
    },
    "ProtocolFeaturesSupported": {
        "DeepOperations": {
            "DeepPATCH": false,
            "DeepPOST": false
        },
        "ExcerptQuery": false,
        "ExpandQuery": {
            "ExpandAll": true,
            "Levels": true,
            "Links": true,
            "MaxLevels": 6,
            "NoLinks": true
        },
        "FilterQuery": false,
        "OnlyMemberQuery": true,
        "SelectQuery": true
    },
    "RedfishVersion": "1.17.0",
    "Registries": {
        "@odata.id": "[/redfish/v1/Registries](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FRegistries)"
    },
    "ServiceIdentification": "",
    "SessionService": {
        "@odata.id": "[/redfish/v1/SessionService](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FSessionService)"
    },
    "Tasks": {
        "@odata.id": "[/redfish/v1/TaskService](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FTaskService)"
    },
    "TelemetryService": {
        "@odata.id": "[/redfish/v1/TelemetryService](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FTelemetryService)"
    },
    "UUID": "3f8b0eb4-623a-445e-adb6-ea5f7f894021",
    "UpdateService": {
        "@odata.id": "[/redfish/v1/UpdateService](https://api-pdx-qa6.frg.nvidia.com/admin/redfish-browser?url=https%3A%2F%2F10.84.204.219%2Fredfish%2Fv1%2FUpdateService)"
    },
    "Vendor": "Delta Electronics Inc."
}
```