### PR TITLE
ci: repin dsx GitHub Actions after org transfer

### DIFF
--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -17,8 +17,8 @@ jobs:
       pull-requests: write
     timeout-minutes: 10
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
-        # Refer to https://github.com/NVIDIA/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
+        # Refer to https://github.com/dsx-ai-factory/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
         with:
           days-before-issue-stale: '60'
           days-before-pr-stale: '30'


### PR DESCRIPTION
## Summary

- Repin the shared `stale-check` action from `NVIDIA/dsx-github-actions` to `dsx-ai-factory/dsx-github-actions`.
- Update the adjacent documentation URL to the transferred repository.
- Preserve the action path and pinned commit SHA exactly.

Tracking: [NvBug 6528755](https://nvbugspro.nvidia.com/bug/6528755)

## Validation

- Confirmed the diff is limited to replacing the repository owner/path in `.github/workflows/stale-check.yml`.
- Confirmed no exact `NVIDIA/dsx-github-actions` references remain.
- Confirmed both expected `dsx-ai-factory/dsx-github-actions` references are present.
- Parsed the updated workflow as YAML and ran `git diff --check`.

## Merge timing

Merge this PR only after the repository transfer to `dsx-ai-factory/dsx-github-actions` is complete.
