### PR TITLE
feat: Add methods to get/set EastWestControlEnabled on CX9 NICs in VR…

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.90.0"
+components = ["rust-analyzer"]

--- a/src/ami.rs
+++ b/src/ami.rs
@@ -1401,6 +1401,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -1444,6 +1444,43 @@ impl Redfish for Bmc {
         })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/delta_powershelf.rs
+++ b/src/delta_powershelf.rs
@@ -861,6 +861,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -1210,6 +1210,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -1248,6 +1248,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -681,11 +681,47 @@ pub trait Redfish: Send + Sync + 'static {
     // Only applicable to Dells
     fn set_utc_timezone<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
 
+    // Gets Oem.Nvidia.EastWestControlEnabled from a single CX NIC Settings
+    // Only applicable to Vera-Rubin. `nic_index` must be in 0..8.
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> RedfishFuture<'a, Result<Option<bool>, RedfishError>>;
+
+    // Sets Oem.Nvidia.EastWestControlEnabled on a single CX NIC Settings
+    // Only applicable to Vera-Rubin. `nic_index` must be in 0..8.
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+
+    // Gets MAC address for a single CX_NIC_{nic_index}_Port_0 EthernetInterface
+    // Only applicable to Vera-Rubin. `nic_index` must be in 0..8.
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+
+    // Gets Model and Name from Chassis/CX_{nic_index}
+    // Only applicable to Vera-Rubin. `nic_index` must be in 0..8.
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> RedfishFuture<'a, Result<Option<SpxNicModelAndName>, RedfishError>>;
+
     // Sets the NTP servers
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],
     ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+}
+
+/// Model and Name from a Vera-Rubin CX NIC chassis (`Chassis/CX_{index}`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpxNicModelAndName {
+    pub model: String,
+    pub name: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -886,6 +886,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -1105,6 +1105,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -1079,6 +1079,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -1389,6 +1389,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -1092,6 +1092,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/nvidia_vera_rubin.rs
+++ b/src/nvidia_vera_rubin.rs
@@ -1383,6 +1383,105 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    // Get the EastWestControlEnabled attribute for the CX NIC with the given index
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            if nic_index >= 8 {
+                return Err(RedfishError::GenericError {
+                    error: format!("nic_index {nic_index} out of range; expected 0..8"),
+                });
+            }
+            let url = format!("Chassis/CX_{nic_index}/NetworkAdapters/CX_NIC_{nic_index}/Settings");
+            let (_status_code, body): (StatusCode, HashMap<String, serde_json::Value>) =
+                self.s.client.get(&url).await?;
+            let oem = jsonmap::get_object(&body, "Oem", &url)?;
+            let nvidia = jsonmap::get_object(oem, "Nvidia", &url)?;
+            Ok(Some(jsonmap::get_bool(
+                nvidia,
+                "EastWestControlEnabled",
+                &url,
+            )?))
+        })
+    }
+
+    // Set the EastWestControlEnabled attribute to the given value for the CX NIC with the given index
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            if nic_index >= 8 {
+                return Err(RedfishError::GenericError {
+                    error: format!("nic_index {nic_index} out of range; expected 0..8"),
+                });
+            }
+            let body = serde_json::json!({
+                "Oem": {
+                    "Nvidia": {
+                        "EastWestControlEnabled": enabled
+                    }
+                }
+            });
+            let url = format!("Chassis/CX_{nic_index}/NetworkAdapters/CX_NIC_{nic_index}/Settings");
+            self.s.client.patch(&url, &body).await?;
+            Ok(())
+        })
+    }
+
+    // Get the MAC address for the CX NIC with the given index
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            if nic_index >= 8 {
+                return Err(RedfishError::GenericError {
+                    error: format!("nic_index {nic_index} out of range; expected 0..8"),
+                });
+            }
+            let url = format!(
+                "Systems/{}/EthernetInterfaces/CX_NIC_{nic_index}_Port_0",
+                self.s.system_id()
+            );
+            let (_status_code, iface): (StatusCode, crate::EthernetInterface) =
+                self.s.client.get(&url).await?;
+            let mac = iface.mac_address.ok_or_else(|| RedfishError::MissingKey {
+                key: "MACAddress".to_string(),
+                url: url.clone(),
+            })?;
+            Ok(Some(mac))
+        })
+    }
+
+    // Get the model and name for the CX NIC with the given index
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move {
+            if nic_index >= 8 {
+                return Err(RedfishError::GenericError {
+                    error: format!("nic_index {nic_index} out of range; expected 0..8"),
+                });
+            }
+            let chassis_id = format!("CX_{nic_index}");
+            let chassis = self.get_chassis(&chassis_id).await?;
+            let model = chassis.model.ok_or_else(|| RedfishError::MissingKey {
+                key: "Model".to_string(),
+                url: format!("Chassis/{chassis_id}"),
+            })?;
+            let name = chassis.name.ok_or_else(|| RedfishError::MissingKey {
+                key: "Name".to_string(),
+                url: format!("Chassis/{chassis_id}"),
+            })?;
+            Ok(Some(crate::SpxNicModelAndName { model, name }))
+        })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -1280,6 +1280,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -1314,6 +1314,47 @@ impl Redfish for RedfishStandard {
         })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        _nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            // Not applicable for non-Vera-Rubin vendors
+            Ok(None)
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        _nic_index: u8,
+        _enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            // No-op for non-Vera-Rubin vendors
+            Ok(())
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        _nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move {
+            // Not applicable for non-Vera-Rubin vendors
+            Ok(None)
+        })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        _nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move {
+            // Not applicable for non-Vera-Rubin vendors
+            Ok(None)
+        })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -1254,6 +1254,43 @@ impl Redfish for Bmc {
         Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
+    fn get_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .get_spx_nic_east_west_control_enabled(nic_index)
+                .await
+        })
+    }
+
+    fn set_spx_nic_east_west_control_enabled<'a>(
+        &'a self,
+        nic_index: u8,
+        enabled: bool,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            self.s
+                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
+                .await
+        })
+    }
+
+    fn get_spx_nic_mac_address<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
+    }
+
+    fn get_spx_nic_model_and_name<'a>(
+        &'a self,
+        nic_index: u8,
+    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
+        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
+    }
+
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],


### PR DESCRIPTION
… platforms

Carbide will use them during ingestion to enable EastWestControlEnabled so that the CX9 NICs become visible on the PCI bus of the DPUs can be controlled by DPF.