### PR TITLE
refactor: delegate Redfish defaults to RedfishStandard

### DIFF
--- a/src/ami.rs
+++ b/src/ami.rs
@@ -26,29 +26,14 @@ use std::{collections::HashMap, path::Path, time::Duration};
 use crate::{
     jsonmap,
     model::{
-        account_service::ManagerAccount,
         boot::{self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode},
-        certificate::Certificate,
-        chassis::{Assembly, Chassis, NetworkAdapter},
-        component_integrity::ComponentIntegrities,
-        network_device_function::NetworkDeviceFunction,
-        oem::nvidia_dpu::{HostPrivilegeLevel, NicMode},
-        power::Power,
-        secure_boot::SecureBoot,
-        sel::LogEntry,
-        sensor::GPUSensors,
-        service_root::{RedfishVendor, ServiceRoot},
-        software_inventory::SoftwareInventory,
-        storage::Drives,
-        task::Task,
-        thermal::Thermal,
-        update_service::{ComponentType, TransferProtocolType, UpdateService},
-        BootOption, ComputerSystem, Manager, ManagerResetType,
+        service_root::RedfishVendor,
+        update_service::ComponentType,
+        BootOption, ComputerSystem, ManagerResetType,
     },
     standard::RedfishStandard,
-    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, JobState, MachineSetupDiff,
-    MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, RoleId,
-    Status, StatusInternal, SystemPowerControl,
+    BiosProfileType, Boot, EnabledDisabled, MachineSetupDiff, MachineSetupStatus, Redfish,
+    RedfishError, Status, StatusInternal,
 };
 
 /// AMI uses BIOS attribute SETUP001 for Administrator Password (UEFI password)
@@ -242,22 +227,9 @@ impl Bmc {
     }
 }
 impl Redfish for Bmc {
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
     /// AMI BMC requires If-Match header for password changes
     fn change_password_by_id<'a>(
         &'a self,
@@ -270,79 +242,6 @@ impl Redfish for Bmc {
             data.insert("Password", new_pass);
             self.s.client.patch_with_if_match(&url, data).await
         })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
-    }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<SoftwareInventory, RedfishError>> {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(&'a self, id: &'a str) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_power_state<'a>(&'a self) -> crate::RedfishFuture<'a, Result<PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
-    }
-
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn get_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
     }
 
     /// AMI BMC requires If-Match header for secure boot changes
@@ -365,48 +264,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_secure_boot_certificate<'a>(
-        &'a self,
-        database_id: &'a str,
-        certificate_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_secure_boot_certificate(database_id, certificate_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot_certificates<'a>(
-        &'a self,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_power_metrics<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Power, RedfishError>> {
-        Box::pin(async move { self.s.get_power_metrics().await })
-    }
-
-    fn power<'a>(
-        &'a self,
-        action: SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.power(action).await })
-    }
-
     /// AMI BMCs are assumed to only accept `ForceRestart` for `Manager.Reset`
     /// (per the AMI support work, #34). `None` defaults to `ForceRestart`; an
     /// explicit non-`ForceRestart` `reset_type` is rejected rather than
@@ -427,49 +284,6 @@ impl Redfish for Bmc {
                 ))),
             }
         })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
-    }
-
-    fn get_thermal_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Thermal, RedfishError>> {
-        Box::pin(async move { self.s.get_thermal_metrics().await })
-    }
-
-    fn get_gpu_sensors<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<GPUSensors>, RedfishError>> {
-        Box::pin(async move { self.s.get_gpu_sensors().await })
-    }
-
-    fn get_system_event_log<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_system_event_log().await })
-    }
-
-    fn get_bmc_event_log<'a>(
-        &'a self,
-        from: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_bmc_event_log(from).await })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
     }
 
     /// Machine setup for AMI BMC.
@@ -705,19 +519,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
-    }
-
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             Redfish::set_boot_override(
@@ -808,19 +609,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn pcie_devices<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<PCIeDevice>, RedfishError>> {
-        Box::pin(async move { self.s.pcie_devices().await })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
     fn update_firmware_multipart<'a>(
         &'a self,
         filename: &'a Path,
@@ -883,25 +671,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>> {
-        Box::pin(async move { self.s.bios().await })
-    }
-
     /// AMI BMC requires If-Match header for BIOS changes
     fn set_bios<'a>(
         &'a self,
@@ -950,119 +719,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_network_device_functions<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_network_device_functions(chassis_id).await })
-    }
-
-    fn get_network_device_function<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-        port: Option<&'a str>,
-    ) -> crate::RedfishFuture<'a, Result<NetworkDeviceFunction, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_network_device_function(chassis_id, id, port)
-                .await
-        })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
-    fn get_chassis_assembly<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapters<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapters(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapter<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_ports<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_ports(chassis_id, network_adapter).await })
-    }
-
-    fn get_port<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::NetworkPort, RedfishError>> {
-        Box::pin(async move { self.s.get_port(chassis_id, network_adapter, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
-    }
-
-    fn get_system_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interfaces().await })
-    }
-
-    fn get_system_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interface(id).await })
-    }
-
     /// AMI uses BIOS attribute SETUP001 for Administrator Password
     fn change_uefi_password<'a>(
         &'a self,
@@ -1081,27 +737,6 @@ impl Redfish for Bmc {
         current_uefi_password: &'a str,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
     }
 
     /// Set the DPU as the first boot option.
@@ -1181,18 +816,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
-    }
-
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
     /// AMI lockdown_bmc - BMC-only lockdown (Host Interface only)
     fn lockdown_bmc<'a>(
         &'a self,
@@ -1204,12 +827,6 @@ impl Redfish for Bmc {
             let hi_url = format!("Managers/{}/HostInterfaces/Self", self.s.manager_id());
             self.s.client.patch_with_if_match(&hi_url, hi_body).await
         })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
     }
 
     /// AMI BMC requires If-Match header for network protocol changes
@@ -1225,10 +842,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
     /// AMI clear_nvram - sets RECV000 (Reset NVRAM) to "Enabled"
     fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
@@ -1242,19 +855,6 @@ impl Redfish for Bmc {
             self.set_bios(HashMap::from([("RECV000".to_string(), "Enabled".into())]))
                 .await
         })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
     }
 
     fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -1297,145 +897,9 @@ impl Redfish for Bmc {
         })
     }
 
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
-    }
-
-    fn get_component_integrities<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
-        Box::pin(async move { self.s.get_component_integrities().await })
-    }
-
-    fn get_firmware_for_component<'a>(
-        &'a self,
-        component_integrity_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<SoftwareInventory, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_firmware_for_component(component_integrity_id)
-                .await
-        })
-    }
-
-    fn get_component_ca_certificate<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
-    }
-
-    fn trigger_evidence_collection<'a>(
-        &'a self,
-        url: &'a str,
-        nonce: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
-    }
-
-    fn get_evidence<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
-    {
-        Box::pin(async move { self.s.get_evidence(url).await })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
     /// AMI doesn't support AC power cycle through standard power action
     fn ac_powercycle_supported_by_power(&self) -> bool {
         false
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
     }
 
     fn set_ntp_servers<'a>(

--- a/src/dell.rs
+++ b/src/dell.rs
@@ -30,33 +30,19 @@ use tokio::fs::File;
 use crate::{
     jsonmap,
     model::{
-        account_service::ManagerAccount,
         boot::BootOverride,
-        certificate::Certificate,
-        chassis::{Assembly, Chassis, NetworkAdapter},
-        component_integrity::ComponentIntegrities,
+        chassis::NetworkAdapter,
         network_device_function::NetworkDeviceFunction,
-        oem::{
-            dell::{self, ShareParameters, StorageCollection, SystemConfiguration},
-            nvidia_dpu::{HostPrivilegeLevel, NicMode},
-        },
-        power::Power,
+        oem::dell::{self, ShareParameters, StorageCollection, SystemConfiguration},
         resource::ResourceCollection,
-        secure_boot::SecureBoot,
         sel::{LogEntry, LogEntryCollection},
-        sensor::GPUSensors,
-        service_root::{RedfishVendor, ServiceRoot},
-        software_inventory::SoftwareInventory,
-        storage::Drives,
-        task::Task,
-        thermal::Thermal,
-        update_service::{ComponentType, TransferProtocolType, UpdateService},
-        BootOption, ComputerSystem, InvalidValueError, Manager, OnOff,
+        service_root::RedfishVendor,
+        update_service::ComponentType,
+        BootOption, InvalidValueError, OnOff,
     },
     standard::RedfishStandard,
-    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, JobState, MachineSetupDiff,
-    MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, RoleId,
-    Status, StatusInternal, SystemPowerControl,
+    BiosProfileType, Boot, EnabledDisabled, JobState, MachineSetupDiff, MachineSetupStatus,
+    PowerState, Redfish, RedfishError, RoleId, Status, StatusInternal, SystemPowerControl,
 };
 
 const UEFI_PASSWORD_NAME: &str = "SetupPassword";
@@ -106,6 +92,9 @@ pub struct Bmc {
     s: RedfishStandard,
 }
 impl Redfish for Bmc {
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
+    }
     fn create_user<'a>(
         &'a self,
         username: &'a str,
@@ -142,51 +131,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        username: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(username, new_pass).await })
-    }
-
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_power_state<'a>(&'a self) -> crate::RedfishFuture<'a, Result<PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
-    }
-
-    fn get_power_metrics<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Power, RedfishError>> {
-        Box::pin(async move { self.s.get_power_metrics().await })
-    }
-
     fn power<'a>(
         &'a self,
         action: SystemPowerControl,
@@ -216,39 +160,6 @@ impl Redfish for Bmc {
         true
     }
 
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
-    }
-
-    fn get_thermal_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Thermal, RedfishError>> {
-        Box::pin(async move { self.s.get_thermal_metrics().await })
-    }
-
-    fn get_gpu_sensors<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<GPUSensors>, RedfishError>> {
-        Box::pin(async move { self.s.get_gpu_sensors().await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
-    }
-
     fn get_system_event_log<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
@@ -263,18 +174,6 @@ impl Redfish for Bmc {
             // Different Dell timestamp formats (UTC-5, DST, etc..) are making filtering and comparing very difficult
             self.s.get_bmc_event_log(from).await
         })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
-    }
-
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>> {
-        Box::pin(async move { self.s.bios().await })
     }
 
     fn set_bios<'a>(
@@ -302,12 +201,6 @@ impl Redfish for Bmc {
 
     fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.factory_reset_bios().await })
-    }
-
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
     }
 
     fn machine_setup<'a>(
@@ -602,19 +495,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
-    }
-
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             match target {
@@ -748,27 +628,8 @@ impl Redfish for Bmc {
         })
     }
 
-    fn pending<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>> {
-        Box::pin(async move { self.s.pending().await })
-    }
-
     fn clear_pending<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.delete_job_queue().await })
-    }
-
-    fn pcie_devices<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<PCIeDevice>, RedfishError>> {
-        Box::pin(async move { self.s.pcie_devices().await })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
     }
 
     /// update_firmware_multipart returns a string with the task ID
@@ -816,77 +677,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<SoftwareInventory, RedfishError>> {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_secure_boot_certificate<'a>(
-        &'a self,
-        database_id: &'a str,
-        certificate_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_secure_boot_certificate(database_id, certificate_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot_certificates<'a>(
-        &'a self,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
-    }
-
-    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_secure_boot().await })
-    }
-
-    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.disable_secure_boot().await })
-    }
-
     fn get_network_device_function<'a>(
         &'a self,
         chassis_id: &'a str,
@@ -906,106 +696,6 @@ impl Redfish for Bmc {
             let (_status_code, body) = self.s.client.get(&url).await?;
             Ok(body)
         })
-    }
-
-    fn get_network_device_functions<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_network_device_functions(chassis_id).await })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
-    fn get_chassis_assembly<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapters<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapters(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapter<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_ports<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_ports(chassis_id, network_adapter).await })
-    }
-
-    fn get_port<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::NetworkPort, RedfishError>> {
-        Box::pin(async move { self.s.get_port(chassis_id, network_adapter, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
-    }
-
-    fn get_system_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interfaces().await })
-    }
-
-    fn get_system_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interface(id).await })
     }
 
     fn change_uefi_password<'a>(
@@ -1028,35 +718,6 @@ impl Redfish for Bmc {
 
             Ok(Some(self.create_bios_config_job().await?))
         })
-    }
-
-    fn change_boot_order<'a>(
-        &'a self,
-        boot_array: Vec<String>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_boot_order(boot_array).await })
-    }
-
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
     }
 
     fn get_job_state<'a>(
@@ -1114,20 +775,6 @@ impl Redfish for Bmc {
 
             Ok(job_state)
         })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
     }
 
     // set_boot_order_dpu_first configures the boot order on the Dell to set the HTTP boot
@@ -1217,53 +864,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
     fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let attrs: HashMap<String, serde_json::Value> =
@@ -1286,19 +886,6 @@ impl Redfish for Bmc {
                 infinite_boot_status == EnabledDisabled::Enabled.to_string(),
             ))
         })
-    }
-
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
     }
 
     fn set_idrac_lockdown<'a>(
@@ -1376,59 +963,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_component_integrities<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
-        Box::pin(async move { self.s.get_component_integrities().await })
-    }
-
-    fn get_firmware_for_component<'a>(
-        &'a self,
-        componnent_integrity_id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move {
-            self.s
-                .get_firmware_for_component(componnent_integrity_id)
-                .await
-        })
-    }
-
-    fn get_component_ca_certificate<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
-    }
-
-    fn trigger_evidence_collection<'a>(
-        &'a self,
-        url: &'a str,
-        nonce: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
-    }
-
-    fn get_evidence<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
-    {
-        Box::pin(async move { self.s.get_evidence(url).await })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
     fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let manager_id = self.s.manager_id();
@@ -1442,43 +976,6 @@ impl Redfish for Bmc {
             self.s.client.patch(&url, body).await?;
             Ok(())
         })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
     }
 
     fn set_ntp_servers<'a>(

--- a/src/delta_powershelf.rs
+++ b/src/delta_powershelf.rs
@@ -1,29 +1,24 @@
 use crate::Assembly;
-use std::{collections::HashMap, path::Path, time::Duration};
+use std::collections::HashMap;
 
-use crate::model::account_service::ManagerAccount;
 use crate::model::boot::BootOverride;
 use crate::model::certificate::Certificate;
 use crate::model::component_integrity::ComponentIntegrities;
-use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
 use crate::model::power::{PowerShelf, PowerShelves};
 use crate::model::sensor::GPUSensors;
 use crate::model::service_root::RedfishVendor;
 use crate::model::task::Task;
-use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
 use crate::network::REDFISH_ENDPOINT;
+use crate::MachineSetupStatus;
 use crate::{
     model::{
         chassis::NetworkAdapter,
         sel::{LogEntry, LogEntryCollection},
-        service_root::ServiceRoot,
-        storage::Drives,
-        BootOption, ComputerSystem, Manager,
+        BootOption, ComputerSystem,
     },
     standard::RedfishStandard,
-    BiosProfileType, Collection, NetworkDeviceFunction, ODataId, Redfish, RedfishError, Resource,
+    BiosProfileType, NetworkDeviceFunction, Redfish, RedfishError,
 };
-use crate::{EnabledDisabled, JobState, MachineSetupStatus, RoleId};
 
 pub struct Bmc {
     s: RedfishStandard,
@@ -35,79 +30,9 @@ impl Bmc {
     }
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
     fn get_power_state<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::PowerState, RedfishError>> {
@@ -129,21 +54,6 @@ impl Redfish for Bmc {
         Box::pin(async move { self.set_psu_power(action).await })
     }
 
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
-    }
-
     fn get_thermal_metrics<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::Thermal, RedfishError>> {
@@ -163,19 +73,6 @@ impl Redfish for Bmc {
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
         Box::pin(async move { self.get_system_event_log().await })
-    }
-
-    fn get_bmc_event_log<'a>(
-        &'a self,
-        from: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_bmc_event_log(from).await })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
     }
 
     fn machine_setup<'a>(
@@ -237,22 +134,6 @@ impl Redfish for Bmc {
         Box::pin(async move { Ok(()) })
     }
 
-    fn lockdown_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.lockdown_status().await })
-    }
-
-    fn setup_serial_console<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.setup_serial_console().await })
-    }
-
-    fn serial_console_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.serial_console_status().await })
-    }
-
     fn get_boot_options<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::BootOptions, RedfishError>> {
@@ -307,10 +188,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_tpm().await })
-    }
-
     fn pcie_devices<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<crate::PCIeDevice>, RedfishError>> {
@@ -319,69 +196,6 @@ impl Redfish for Bmc {
                 "Delta powershelf doesn't have PCIeDevices tree".to_string(),
             ))
         })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
-    }
-
-    // TODO: power-shelf firmware updates aren't exercised via libredfish today; until there's
-    // a concrete need, defer to the standard multipart push
-    fn update_firmware_multipart<'a>(
-        &'a self,
-        filename: &'a Path,
-        reboot: bool,
-        timeout: Duration,
-        component_type: ComponentType,
-    ) -> crate::RedfishFuture<'a, Result<String, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_multipart(filename, reboot, timeout, component_type)
-                .await
-        })
-    }
-
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.bios().await })
-    }
-
-    fn set_bios<'a>(
-        &'a self,
-        values: HashMap<String, serde_json::Value>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_bios(values).await })
-    }
-
-    fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.reset_bios().await })
-    }
-
-    /// delta powershelf has no bios attributes
-    fn pending<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.pending().await })
-    }
-
-    fn clear_pending<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_pending().await })
     }
 
     /// Delta power shelves expose no `/Systems` resource, but the site
@@ -409,20 +223,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_secure_boot<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::secure_boot::SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
-    }
-
-    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_secure_boot().await })
-    }
-
-    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.disable_secure_boot().await })
-    }
-
     fn add_secure_boot_certificate<'a>(
         &'a self,
         _pem_cert: &'a str,
@@ -433,19 +233,6 @@ impl Redfish for Bmc {
                 "Delta powershelf secure boot unsupported".to_string(),
             ))
         })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
     }
 
     fn get_chassis_network_adapters<'a>(
@@ -469,34 +256,6 @@ impl Redfish for Bmc {
                 "Delta powershelf doesn't have NetworkAdapters tree".to_string(),
             ))
         })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
     }
 
     fn get_system_ethernet_interfaces<'a>(
@@ -591,49 +350,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
     fn set_boot_order_dpu_first<'a>(
         &'a self,
         _boot_interface: crate::BootInterfaceRef<'a>,
@@ -650,117 +366,6 @@ impl Redfish for Bmc {
         current_uefi_password: &'a str,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
-    }
-
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
-    fn is_infinite_boot_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move { self.s.is_infinite_boot_enabled().await })
-    }
-
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
     }
 
     fn get_secure_boot_certificate<'a>(
@@ -848,61 +453,6 @@ impl Redfish for Bmc {
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
         Box::pin(async move { Err(RedfishError::NotSupported("not supported".to_string())) })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 

--- a/src/hpe.rs
+++ b/src/hpe.rs
@@ -20,40 +20,26 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
  * DEALINGS IN THE SOFTWARE.
  */
-use std::{collections::HashMap, path::Path, time::Duration};
+use std::collections::HashMap;
 
 use serde_json::Value;
 
 use crate::{
     model::{
-        account_service::ManagerAccount,
         boot::BootOverride,
-        certificate::Certificate,
-        chassis::{Assembly, Chassis, NetworkAdapter},
-        component_integrity::ComponentIntegrities,
-        network_device_function::NetworkDeviceFunction,
-        oem::{
-            hpe::{self, BootDevices},
-            nvidia_dpu::{HostPrivilegeLevel, NicMode},
-        },
-        power::Power,
-        secure_boot::SecureBoot,
+        chassis::NetworkAdapter,
+        oem::hpe::{self, BootDevices},
         sel::{LogEntry, LogEntryCollection},
-        sensor::GPUSensors,
-        service_root::{RedfishVendor, ServiceRoot},
-        software_inventory::SoftwareInventory,
-        storage::{self, Drives},
-        task::Task,
-        thermal::Thermal,
-        update_service::{ComponentType, TransferProtocolType, UpdateService},
-        BootOption, ComputerSystem, Manager, Slot, SystemStatus,
+        service_root::RedfishVendor,
+        storage::{self},
+        Slot, SystemStatus,
     },
     network::REDFISH_ENDPOINT,
     standard::RedfishStandard,
-    BiosProfileType, Boot, BootOptions, Collection, Deserialize,
+    BiosProfileType, Boot, Deserialize,
     EnabledDisabled::{self, Disabled, Enabled},
-    JobState, MachineSetupDiff, MachineSetupStatus, OData, ODataId, PCIeDevice, PowerState,
-    Redfish, RedfishError, Resource, RoleId, Serialize, Status, StatusInternal, SystemPowerControl,
+    MachineSetupDiff, MachineSetupStatus, OData, ODataId, PCIeDevice, PowerState, Redfish,
+    RedfishError, Serialize, Status, StatusInternal, SystemPowerControl,
 };
 
 // The following is specific for the HPE machine since the HPE redfish
@@ -100,60 +86,9 @@ impl Bmc {
     }
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_power_state<'a>(&'a self) -> crate::RedfishFuture<'a, Result<PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
-    }
-
-    fn get_power_metrics<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Power, RedfishError>> {
-        Box::pin(async move { self.s.get_power_metrics().await })
-    }
-
     fn power<'a>(
         &'a self,
         action: SystemPowerControl,
@@ -187,33 +122,6 @@ impl Redfish for Bmc {
         true
     }
 
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
-    }
-
-    fn get_thermal_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Thermal, RedfishError>> {
-        Box::pin(async move { self.s.get_thermal_metrics().await })
-    }
-
-    fn get_gpu_sensors<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<GPUSensors>, RedfishError>> {
-        Box::pin(async move { self.s.get_gpu_sensors().await })
-    }
-
     fn get_system_event_log<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
@@ -229,25 +137,6 @@ impl Redfish for Bmc {
             let url = format!("Managers/{manager_id}/LogServices/IEL/Entries");
             self.s.fetch_bmc_event_log(url, from).await
         })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
-    }
-
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>> {
-        Box::pin(async move { self.s.bios().await })
-    }
-
-    fn set_bios<'a>(
-        &'a self,
-        values: HashMap<String, serde_json::Value>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_bios(values).await })
     }
 
     fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -456,19 +345,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
-    }
-
     fn boot_first<'a>(
         &'a self,
         target: Boot,
@@ -637,136 +513,10 @@ impl Redfish for Bmc {
         })
     }
 
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
-    fn update_firmware_multipart<'a>(
-        &'a self,
-        filename: &'a Path,
-        reboot: bool,
-        timeout: Duration,
-        component_type: ComponentType,
-    ) -> crate::RedfishFuture<'a, Result<String, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_multipart(filename, reboot, timeout, component_type)
-                .await
-        })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<SoftwareInventory, RedfishError>> {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_secure_boot_certificate<'a>(
-        &'a self,
-        database_id: &'a str,
-        certificate_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_secure_boot_certificate(database_id, certificate_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot_certificates<'a>(
-        &'a self,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
-    }
-
-    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_secure_boot().await })
-    }
-
-    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.disable_secure_boot().await })
-    }
-
-    fn get_network_device_function<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-        port: Option<&'a str>,
-    ) -> crate::RedfishFuture<'a, Result<NetworkDeviceFunction, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_network_device_function(chassis_id, id, port)
-                .await
-        })
-    }
-
-    fn get_network_device_functions<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_network_device_functions(chassis_id).await })
-    }
-
     fn get_chassis_all<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
         Box::pin(async move { self.s.get_members("Chassis").await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
-    fn get_chassis_assembly<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
     }
 
     fn get_chassis_network_adapters<'a>(
@@ -785,14 +535,6 @@ impl Redfish for Bmc {
                 Ok(Vec::new())
             }
         })
-    }
-
-    fn get_chassis_network_adapter<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
     }
 
     fn get_base_network_adapters<'a>(
@@ -815,49 +557,6 @@ impl Redfish for Bmc {
             let (_, body) = self.s.client.get(&url).await?;
             Ok(body)
         })
-    }
-
-    fn get_ports<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_ports(chassis_id, network_adapter).await })
-    }
-
-    fn get_port<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::NetworkPort, RedfishError>> {
-        Box::pin(async move { self.s.get_port(chassis_id, network_adapter, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
-    }
-
-    fn get_system_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interfaces().await })
-    }
-
-    fn get_system_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interface(id).await })
     }
 
     fn change_uefi_password<'a>(
@@ -895,31 +594,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn change_boot_order<'a>(
-        &'a self,
-        boot_array: Vec<String>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_boot_order(boot_array).await })
-    }
-
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
     fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let url = format!(
@@ -931,33 +605,6 @@ impl Redfish for Bmc {
             arg.insert("ResetType", "Default".to_string());
             self.s.client.post(&url, arg).await.map(|_resp| Ok(()))?
         })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
     }
 
     fn set_boot_order_dpu_first<'a>(
@@ -1017,121 +664,6 @@ impl Redfish for Bmc {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
     }
 
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
-    fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_infinite_boot().await })
-    }
-
-    fn is_infinite_boot_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move { self.s.is_infinite_boot_enabled().await })
-    }
-
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
-    }
-
     fn is_boot_order_setup<'a>(
         &'a self,
         boot_interface: crate::BootInterfaceRef<'a>,
@@ -1151,100 +683,6 @@ impl Redfish for Bmc {
             let diffs = self.diff_bios_bmc_attr().await?;
             Ok(diffs.is_empty())
         })
-    }
-
-    fn get_component_integrities<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
-        Box::pin(async move { self.s.get_component_integrities().await })
-    }
-
-    fn get_firmware_for_component<'a>(
-        &'a self,
-        componnent_integrity_id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move {
-            self.s
-                .get_firmware_for_component(componnent_integrity_id)
-                .await
-        })
-    }
-
-    fn get_component_ca_certificate<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
-    }
-
-    fn trigger_evidence_collection<'a>(
-        &'a self,
-        url: &'a str,
-        nonce: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
-    }
-
-    fn get_evidence<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
-    {
-        Box::pin(async move { self.s.get_evidence(url).await })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
     }
 
     fn set_ntp_servers<'a>(

--- a/src/lenovo.rs
+++ b/src/lenovo.rs
@@ -33,39 +33,26 @@ use tokio::fs::File;
 use tokio::time::sleep;
 use tracing::debug;
 
-use crate::model::account_service::ManagerAccount;
 use crate::model::boot::BootOverride;
-use crate::model::certificate::Certificate;
-use crate::model::component_integrity::ComponentIntegrities;
 use crate::model::oem::lenovo::{BootSettings, FrontPanelUSB, LenovoBootOrder};
-use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
 use crate::model::sel::LogService;
-use crate::model::service_root::{RedfishVendor, ServiceRoot};
+use crate::model::service_root::RedfishVendor;
 use crate::model::task::Task;
-use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
-use crate::model::{secure_boot::SecureBoot, ComputerSystem};
-use crate::model::{InvalidValueError, Manager};
+use crate::model::update_service::ComponentType;
+use crate::model::InvalidValueError;
 use crate::{
     jsonmap,
     model::{
-        chassis::{Assembly, Chassis, NetworkAdapter},
-        network_device_function::NetworkDeviceFunction,
         oem::lenovo,
-        power::Power,
         sel::{LogEntry, LogEntryCollection},
-        sensor::GPUSensors,
         software_inventory::SoftwareInventory,
-        storage::Drives,
-        thermal::Thermal,
         BootOption,
     },
     network::REDFISH_ENDPOINT,
     standard::RedfishStandard,
-    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, MachineSetupDiff,
-    MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, Status,
-    StatusInternal, SystemPowerControl,
+    BiosProfileType, Boot, EnabledDisabled, MachineSetupDiff, MachineSetupStatus, PowerState,
+    Redfish, RedfishError, Status, StatusInternal, SystemPowerControl,
 };
-use crate::{JobState, RoleId};
 
 const UEFI_PASSWORD_NAME: &str = "UefiAdminPassword";
 const GENERAL_BOOT_ORDER_HARD_DISK: &str = "Hard Disk";
@@ -80,60 +67,9 @@ impl Bmc {
     }
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_power_state<'a>(&'a self) -> crate::RedfishFuture<'a, Result<PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
-    }
-
-    fn get_power_metrics<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Power, RedfishError>> {
-        Box::pin(async move { self.s.get_power_metrics().await })
-    }
-
     fn power<'a>(
         &'a self,
         action: SystemPowerControl,
@@ -174,33 +110,6 @@ impl Redfish for Bmc {
         true
     }
 
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
-    }
-
-    fn get_thermal_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Thermal, RedfishError>> {
-        Box::pin(async move { self.s.get_thermal_metrics().await })
-    }
-
-    fn get_gpu_sensors<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<GPUSensors>, RedfishError>> {
-        Box::pin(async move { self.s.get_gpu_sensors().await })
-    }
-
     fn get_system_event_log<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
@@ -218,18 +127,6 @@ impl Redfish for Bmc {
             );
             self.s.fetch_bmc_event_log(url, from).await
         })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
-    }
-
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>> {
-        Box::pin(async move { self.s.bios().await })
     }
 
     fn set_bios<'a>(
@@ -559,19 +456,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
-    }
-
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             match target {
@@ -642,25 +526,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn pcie_devices<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<PCIeDevice>, RedfishError>> {
-        Box::pin(async move { self.s.pcie_devices().await })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
-    }
-
     fn update_firmware_multipart<'a>(
         &'a self,
         filename: &'a Path,
@@ -715,17 +580,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
     fn get_firmware<'a>(
         &'a self,
         id: &'a str,
@@ -738,172 +592,6 @@ impl Redfish for Bmc {
                 .map(|x| x.split('-').next_back().unwrap_or("").to_string());
             Ok(inv)
         })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_secure_boot_certificate<'a>(
-        &'a self,
-        database_id: &'a str,
-        certificate_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_secure_boot_certificate(database_id, certificate_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot_certificates<'a>(
-        &'a self,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
-    }
-
-    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_secure_boot().await })
-    }
-
-    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.disable_secure_boot().await })
-    }
-
-    fn get_network_device_function<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-        port: Option<&'a str>,
-    ) -> crate::RedfishFuture<'a, Result<NetworkDeviceFunction, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_network_device_function(chassis_id, id, port)
-                .await
-        })
-    }
-
-    fn get_network_device_functions<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_network_device_functions(chassis_id).await })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
-    fn get_chassis_assembly<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapters<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapters(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapter<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_ports<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_ports(chassis_id, network_adapter).await })
-    }
-
-    fn get_port<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::NetworkPort, RedfishError>> {
-        Box::pin(async move { self.s.get_port(chassis_id, network_adapter, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
-    }
-
-    fn get_system_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interfaces().await })
-    }
-
-    fn get_system_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interface(id).await })
     }
 
     fn change_uefi_password<'a>(
@@ -947,49 +635,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
     fn set_boot_order_dpu_first<'a>(
         &'a self,
         boot_interface: crate::BootInterfaceRef<'a>,
@@ -1023,66 +668,6 @@ impl Redfish for Bmc {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
     }
 
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
     fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let attrs: HashMap<String, serde_json::Value> =
@@ -1107,51 +692,6 @@ impl Redfish for Bmc {
             Ok(Some(
                 infinite_boot_status == EnabledDisabled::Enabled.to_string(),
             ))
-        })
-    }
-
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
         })
     }
 
@@ -1189,107 +729,6 @@ impl Redfish for Bmc {
             let diffs = self.diff_bios_bmc_attr().await?;
             Ok(diffs.is_empty())
         })
-    }
-
-    fn get_component_integrities<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
-        Box::pin(async move { self.s.get_component_integrities().await })
-    }
-
-    fn get_firmware_for_component<'a>(
-        &'a self,
-        componnent_integrity_id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move {
-            self.s
-                .get_firmware_for_component(componnent_integrity_id)
-                .await
-        })
-    }
-
-    fn get_component_ca_certificate<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
-    }
-
-    fn trigger_evidence_collection<'a>(
-        &'a self,
-        url: &'a str,
-        nonce: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
-    }
-
-    fn get_evidence<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
-    {
-        Box::pin(async move { self.s.get_evidence(url).await })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,12 +80,21 @@ pub type RedfishFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Interface to a BMC Redfish server. All calls will include one or more HTTP network calls.
 pub trait Redfish: Send + Sync + 'static {
+    /// Returns the standard Redfish implementation used for default behavior.
+    fn std_redfish(&self) -> &standard::RedfishStandard;
+
     /// Rename a user
     fn change_username<'a>(
         &'a self,
         old_name: &'a str,
         new_name: &'a str,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::change_username(
+            self.std_redfish(),
+            old_name,
+            new_name,
+        )
+    }
 
     /// Change password by username
     /// This looks up the ID for given username before calling change_password_by_id.
@@ -95,17 +104,31 @@ pub trait Redfish: Send + Sync + 'static {
         &'a self,
         username: &'a str,
         new_pass: &'a str,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::change_password(
+            self.std_redfish(),
+            username,
+            new_pass,
+        )
+    }
 
     /// Change password by id
     fn change_password_by_id<'a>(
         &'a self,
         account_id: &'a str,
         new_pass: &'a str,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::change_password_by_id(
+            self.std_redfish(),
+            account_id,
+            new_pass,
+        )
+    }
 
     /// List current user accounts
-    fn get_accounts<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>>;
+    fn get_accounts<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_accounts(self.std_redfish())
+    }
 
     /// Create a new user
     fn create_user<'a>(
@@ -113,65 +136,111 @@ pub trait Redfish: Send + Sync + 'static {
         username: &'a str,
         password: &'a str,
         role_id: RoleId,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::create_user(
+            self.std_redfish(),
+            username,
+            password,
+            role_id,
+        )
+    }
 
     /// Delete a BMC user
-    fn delete_user<'a>(&'a self, username: &'a str) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn delete_user<'a>(&'a self, username: &'a str) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::delete_user(self.std_redfish(), username)
+    }
 
     // Get firmware version for particular firmware inventory id
     fn get_firmware<'a>(
         &'a self,
         id: &'a str,
-    ) -> RedfishFuture<'a, Result<SoftwareInventory, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<SoftwareInventory, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_firmware(self.std_redfish(), id)
+    }
 
     // Get software inventory collection
     fn get_software_inventories<'a>(
         &'a self,
-    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_software_inventories(self.std_redfish())
+    }
 
     // List all Tasks
-    fn get_tasks<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    fn get_tasks<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_tasks(self.std_redfish())
+    }
 
     // Get information about a task
-    fn get_task<'a>(&'a self, id: &'a str) -> RedfishFuture<'a, Result<Task, RedfishError>>;
+    fn get_task<'a>(&'a self, id: &'a str) -> RedfishFuture<'a, Result<Task, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_task(self.std_redfish(), id)
+    }
 
     /// Is this thing even on?
-    fn get_power_state<'a>(&'a self) -> RedfishFuture<'a, Result<PowerState, RedfishError>>;
+    fn get_power_state<'a>(&'a self) -> RedfishFuture<'a, Result<PowerState, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_power_state(self.std_redfish())
+    }
 
     /// Returns info about operations that the service supports.
-    fn get_service_root<'a>(&'a self) -> RedfishFuture<'a, Result<ServiceRoot, RedfishError>>;
+    fn get_service_root<'a>(&'a self) -> RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_service_root(self.std_redfish())
+    }
 
     /// Returns info about available computer systems.
-    fn get_systems<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    fn get_systems<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_systems(self.std_redfish())
+    }
 
     /// Returns info about computer system.
-    fn get_system<'a>(&'a self) -> RedfishFuture<'a, Result<ComputerSystem, RedfishError>>;
+    fn get_system<'a>(&'a self) -> RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_system(self.std_redfish())
+    }
 
     /// Returns info about available managers.
-    fn get_managers<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    fn get_managers<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_managers(self.std_redfish())
+    }
 
     /// Returns info about managers
-    fn get_manager<'a>(&'a self) -> RedfishFuture<'a, Result<Manager, RedfishError>>;
+    fn get_manager<'a>(&'a self) -> RedfishFuture<'a, Result<Manager, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_manager(self.std_redfish())
+    }
 
     /// Get Secure Boot state
-    fn get_secure_boot<'a>(&'a self) -> RedfishFuture<'a, Result<SecureBoot, RedfishError>>;
+    fn get_secure_boot<'a>(&'a self) -> RedfishFuture<'a, Result<SecureBoot, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_secure_boot(self.std_redfish())
+    }
 
     /// Disables Secure Boot
-    fn disable_secure_boot<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn disable_secure_boot<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::disable_secure_boot(self.std_redfish())
+    }
 
     /// Enables Secure Boot
-    fn enable_secure_boot<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn enable_secure_boot<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::enable_secure_boot(self.std_redfish())
+    }
 
     fn get_secure_boot_certificate<'a>(
         &'a self,
         database_id: &'a str,
         certificate_id: &'a str,
-    ) -> RedfishFuture<'a, Result<Certificate, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Certificate, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_secure_boot_certificate(
+            self.std_redfish(),
+            database_id,
+            certificate_id,
+        )
+    }
 
     fn get_secure_boot_certificates<'a>(
         &'a self,
         database_id: &'a str,
-    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_secure_boot_certificates(
+            self.std_redfish(),
+            database_id,
+        )
+    }
 
     /// Adds certificate to secure boot DB
     /// database_id: "db" for database, "pk" for PK database
@@ -180,16 +249,26 @@ pub trait Redfish: Send + Sync + 'static {
         &'a self,
         pem_cert: &'a str,
         database_id: &'a str,
-    ) -> RedfishFuture<'a, Result<Task, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Task, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::add_secure_boot_certificate(
+            self.std_redfish(),
+            pem_cert,
+            database_id,
+        )
+    }
 
     /// Power supplies and voltages metrics
-    fn get_power_metrics<'a>(&'a self) -> RedfishFuture<'a, Result<Power, RedfishError>>;
+    fn get_power_metrics<'a>(&'a self) -> RedfishFuture<'a, Result<Power, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_power_metrics(self.std_redfish())
+    }
 
     /// Change power state: on, off, reboot, etc
     fn power<'a>(
         &'a self,
         action: SystemPowerControl,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::power(self.std_redfish(), action)
+    }
 
     /// Reboot the BMC itself. `reset_type` selects the Redfish `Manager.Reset`
     /// action; `None` uses the vendor's default (`GracefulRestart` for the
@@ -198,36 +277,57 @@ pub trait Redfish: Send + Sync + 'static {
     fn bmc_reset<'a>(
         &'a self,
         reset_type: Option<ManagerResetType>,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::bmc_reset(self.std_redfish(), reset_type)
+    }
 
     /// Reset Chassis
     fn chassis_reset<'a>(
         &'a self,
         chassis_id: &'a str,
         reset_type: SystemPowerControl,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::chassis_reset(
+            self.std_redfish(),
+            chassis_id,
+            reset_type,
+        )
+    }
 
     /// Reset BMC to the factory defaults.
-    fn bmc_reset_to_defaults<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn bmc_reset_to_defaults<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::bmc_reset_to_defaults(self.std_redfish())
+    }
 
     /// Fans and temperature sensors
-    fn get_thermal_metrics<'a>(&'a self) -> RedfishFuture<'a, Result<Thermal, RedfishError>>;
+    fn get_thermal_metrics<'a>(&'a self) -> RedfishFuture<'a, Result<Thermal, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_thermal_metrics(self.std_redfish())
+    }
 
     /// Voltage, temperature, etc sensors for gpus if they exist.
-    fn get_gpu_sensors<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<GPUSensors>, RedfishError>>;
+    fn get_gpu_sensors<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<GPUSensors>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_gpu_sensors(self.std_redfish())
+    }
 
     /// get system event log similar to ipmitool sel
-    fn get_system_event_log<'a>(&'a self)
-        -> RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>>;
+    fn get_system_event_log<'a>(
+        &'a self,
+    ) -> RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_system_event_log(self.std_redfish())
+    }
 
     /// get bmc event log (power events, etc.)
     fn get_bmc_event_log<'a>(
         &'a self,
         from: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_bmc_event_log(self.std_redfish(), from)
+    }
 
     /// get drives metrics
-    fn get_drives_metrics<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<Drives>, RedfishError>>;
+    fn get_drives_metrics<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_drives_metrics(self.std_redfish())
+    }
 
     /// Sets up a reasonable UEFI configuration.
     /// remember to call lockdown() afterwards to secure the server
@@ -252,54 +352,87 @@ pub trait Redfish: Send + Sync + 'static {
         bios_profiles: &'a BiosProfileVendor,
         selected_profile: BiosProfileType,
         oem_manager_profiles: &'a BiosProfileVendor,
-    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::machine_setup(
+            self.std_redfish(),
+            boot_interface,
+            bios_profiles,
+            selected_profile,
+            oem_manager_profiles,
+        )
+    }
 
     /// Is everything that machine_setup does already done?
     fn machine_setup_status<'a>(
         &'a self,
         boot_interface: Option<BootInterfaceRef<'a>>,
-    ) -> RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<MachineSetupStatus, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::machine_setup_status(
+            self.std_redfish(),
+            boot_interface,
+        )
+    }
 
     /// Check if only the BIOS/BMC setup is done
     fn is_bios_setup<'a>(
         &'a self,
         boot_interface: Option<BootInterfaceRef<'a>>,
-    ) -> RedfishFuture<'a, Result<bool, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<bool, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::is_bios_setup(self.std_redfish(), boot_interface)
+    }
 
     /// Apply a standard BMC password policy. This varies a lot by vendor,
     /// but at a minimum we want passwords to never expire, because our BMCs are
     /// not actively used by humans.
-    fn set_machine_password_policy<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn set_machine_password_policy<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_machine_password_policy(self.std_redfish())
+    }
 
     /// Lock the BIOS and BMC ready for tenant use. Disabled reverses the changes.
     fn lockdown<'a>(
         &'a self,
         target: EnabledDisabled,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::lockdown(self.std_redfish(), target)
+    }
 
     /// Are the BIOS and BMC currently locked down?
-    fn lockdown_status<'a>(&'a self) -> RedfishFuture<'a, Result<Status, RedfishError>>;
+    fn lockdown_status<'a>(&'a self) -> RedfishFuture<'a, Result<Status, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::lockdown_status(self.std_redfish())
+    }
 
     /// Enable SSH access to console
-    fn setup_serial_console<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn setup_serial_console<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::setup_serial_console(self.std_redfish())
+    }
 
     /// Is the serial console setup?
-    fn serial_console_status<'a>(&'a self) -> RedfishFuture<'a, Result<Status, RedfishError>>;
+    fn serial_console_status<'a>(&'a self) -> RedfishFuture<'a, Result<Status, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::serial_console_status(self.std_redfish())
+    }
 
     /// Show available boot options
-    fn get_boot_options<'a>(&'a self) -> RedfishFuture<'a, Result<BootOptions, RedfishError>>;
+    fn get_boot_options<'a>(&'a self) -> RedfishFuture<'a, Result<BootOptions, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_boot_options(self.std_redfish())
+    }
 
     /// Show available boot options
     fn get_boot_option<'a>(
         &'a self,
         option_id: &'a str,
-    ) -> RedfishFuture<'a, Result<BootOption, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<BootOption, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_boot_option(self.std_redfish(), option_id)
+    }
 
     /// Boot a single time of the given target. Does not change boot order after that.
-    fn boot_once<'a>(&'a self, target: Boot) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn boot_once<'a>(&'a self, target: Boot) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::boot_once(self.std_redfish(), target)
+    }
 
     /// Change boot order putting this target first
-    fn boot_first<'a>(&'a self, target: Boot) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn boot_first<'a>(&'a self, target: Boot) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::boot_first(self.std_redfish(), target)
+    }
 
     /// Set a boot source override, optionally including an HTTP boot URI.
     ///
@@ -320,25 +453,35 @@ pub trait Redfish: Send + Sync + 'static {
     fn set_boot_override<'a>(
         &'a self,
         settings: BootOverride,
-    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_boot_override(self.std_redfish(), settings)
+    }
 
     /// Change boot order by setting boot array.
     fn change_boot_order<'a>(
         &'a self,
         boot_array: Vec<String>,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::change_boot_order(self.std_redfish(), boot_array)
+    }
 
     /// Reset and enable the TPM
-    fn clear_tpm<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn clear_tpm<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::clear_tpm(self.std_redfish())
+    }
 
     /// List PCIe devices
-    fn pcie_devices<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<PCIeDevice>, RedfishError>>;
+    fn pcie_devices<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<PCIeDevice>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::pcie_devices(self.std_redfish())
+    }
 
     /// Update BMC firmware
     fn update_firmware<'a>(
         &'a self,
         filename: tokio::fs::File,
-    ) -> RedfishFuture<'a, Result<Task, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Task, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::update_firmware(self.std_redfish(), filename)
+    }
 
     /// Update UEFI firmware, returns a task ID
     fn update_firmware_multipart<'a>(
@@ -347,7 +490,15 @@ pub trait Redfish: Send + Sync + 'static {
         reboot: bool,
         timeout: Duration,
         component_type: ComponentType,
-    ) -> RedfishFuture<'a, Result<String, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<String, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::update_firmware_multipart(
+            self.std_redfish(),
+            firmware,
+            reboot,
+            timeout,
+            component_type,
+        )
+    }
 
     /// This action shall update installed software components in a software image file located at an ImageURI parameter-specified URI.
     /// image_uri - The URI of the software image to install.
@@ -359,7 +510,14 @@ pub trait Redfish: Send + Sync + 'static {
         image_uri: &'a str,
         targets: Vec<String>,
         transfer_protocol: TransferProtocolType,
-    ) -> RedfishFuture<'a, Result<Task, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Task, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::update_firmware_simple_update(
+            self.std_redfish(),
+            image_uri,
+            targets,
+            transfer_protocol,
+        )
+    }
 
     /*
      * Diagnostic calls
@@ -367,31 +525,46 @@ pub trait Redfish: Send + Sync + 'static {
     /// All the BIOS values for this provider. Very OEM specific.
     fn bios<'a>(
         &'a self,
-    ) -> RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::bios(self.std_redfish())
+    }
 
     /// Modify specific BIOS values.  Also very OEM and model specific.
     fn set_bios<'a>(
         &'a self,
         values: HashMap<String, serde_json::Value>,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_bios(self.std_redfish(), values)
+    }
 
     /// Reset BIOS to factory settings
-    fn reset_bios<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn reset_bios<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::reset_bios(self.std_redfish())
+    }
 
     /// Pending BIOS attributes. Changes that were requested but not applied yet because
     /// they need a reboot.
     fn pending<'a>(
         &'a self,
-    ) -> RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::pending(self.std_redfish())
+    }
 
     /// Clear all pending jobs
-    fn clear_pending<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn clear_pending<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::clear_pending(self.std_redfish())
+    }
 
     // List all Network Device Functions of a given Chassis
     fn get_network_device_functions<'a>(
         &'a self,
         chassis_id: &'a str,
-    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_network_device_functions(
+            self.std_redfish(),
+            chassis_id,
+        )
+    }
 
     // Get Network Device Function details
     fn get_network_device_function<'a>(
@@ -399,39 +572,68 @@ pub trait Redfish: Send + Sync + 'static {
         chassis_id: &'a str,
         id: &'a str,
         port: Option<&'a str>,
-    ) -> RedfishFuture<'a, Result<NetworkDeviceFunction, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<NetworkDeviceFunction, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_network_device_function(
+            self.std_redfish(),
+            chassis_id,
+            id,
+            port,
+        )
+    }
 
     // List all Chassises
-    fn get_chassis_all<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    fn get_chassis_all<'a>(&'a self) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_chassis_all(self.std_redfish())
+    }
 
     // Get Chassis details
-    fn get_chassis<'a>(&'a self, id: &'a str) -> RedfishFuture<'a, Result<Chassis, RedfishError>>;
+    fn get_chassis<'a>(&'a self, id: &'a str) -> RedfishFuture<'a, Result<Chassis, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_chassis(self.std_redfish(), id)
+    }
 
     // Get Chassis Assembly details
     fn get_chassis_assembly<'a>(
         &'a self,
         chassis_id: &'a str,
-    ) -> RedfishFuture<'a, Result<Assembly, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Assembly, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_chassis_assembly(self.std_redfish(), chassis_id)
+    }
 
     // List all Network Adapters for the specific Chassis
     fn get_chassis_network_adapters<'a>(
         &'a self,
         chassis_id: &'a str,
-    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_chassis_network_adapters(
+            self.std_redfish(),
+            chassis_id,
+        )
+    }
 
     // Get Network Adapter details for the specific Chassis and Network Adapter
     fn get_chassis_network_adapter<'a>(
         &'a self,
         chassis_id: &'a str,
         id: &'a str,
-    ) -> RedfishFuture<'a, Result<NetworkAdapter, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_chassis_network_adapter(
+            self.std_redfish(),
+            chassis_id,
+            id,
+        )
+    }
 
     // List all Base Network Adapters for the specific Chassis
     // Only implemented in iLO5
     fn get_base_network_adapters<'a>(
         &'a self,
         system_id: &'a str,
-    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_base_network_adapters(
+            self.std_redfish(),
+            system_id,
+        )
+    }
 
     // Get Base Network Adapter details for the specific Chassis and Network Adapter
     // Only implemented in iLO5
@@ -439,14 +641,26 @@ pub trait Redfish: Send + Sync + 'static {
         &'a self,
         system_id: &'a str,
         id: &'a str,
-    ) -> RedfishFuture<'a, Result<NetworkAdapter, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_base_network_adapter(
+            self.std_redfish(),
+            system_id,
+            id,
+        )
+    }
 
     // List all High Speed Ports of a given Chassis
     fn get_ports<'a>(
         &'a self,
         chassis_id: &'a str,
         network_adapter: &'a str,
-    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_ports(
+            self.std_redfish(),
+            chassis_id,
+            network_adapter,
+        )
+    }
 
     // Get High Speed Port details
     fn get_port<'a>(
@@ -454,41 +668,70 @@ pub trait Redfish: Send + Sync + 'static {
         chassis_id: &'a str,
         network_adapter: &'a str,
         id: &'a str,
-    ) -> RedfishFuture<'a, Result<NetworkPort, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<NetworkPort, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_port(
+            self.std_redfish(),
+            chassis_id,
+            network_adapter,
+            id,
+        )
+    }
 
     // List all Ethernet Interfaces for the default `Manager`
     fn get_manager_ethernet_interfaces<'a>(
         &'a self,
-    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_manager_ethernet_interfaces(self.std_redfish())
+    }
 
     // Get Ethernet Interface details for an interface on the default `Manager`
     fn get_manager_ethernet_interface<'a>(
         &'a self,
         id: &'a str,
-    ) -> RedfishFuture<'a, Result<EthernetInterface, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<EthernetInterface, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_manager_ethernet_interface(
+            self.std_redfish(),
+            id,
+        )
+    }
 
     // List all Ethernet Interfaces for the default `System`
     fn get_system_ethernet_interfaces<'a>(
         &'a self,
-    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_system_ethernet_interfaces(self.std_redfish())
+    }
 
     // Get Ethernet Interface details for an interface on the default `System`
     fn get_system_ethernet_interface<'a>(
         &'a self,
         id: &'a str,
-    ) -> RedfishFuture<'a, Result<EthernetInterface, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<EthernetInterface, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_system_ethernet_interface(
+            self.std_redfish(),
+            id,
+        )
+    }
 
     // Change UEFI Password
     fn change_uefi_password<'a>(
         &'a self,
         current_uefi_password: &'a str,
         new_uefi_password: &'a str,
-    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::change_uefi_password(
+            self.std_redfish(),
+            current_uefi_password,
+            new_uefi_password,
+        )
+    }
 
     fn get_job_state<'a>(
         &'a self,
         job_id: &'a str,
-    ) -> RedfishFuture<'a, Result<JobState, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<JobState, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_job_state(self.std_redfish(), job_id)
+    }
 
     /// A kind-of-generic method to retrieve any Redfish resource. A resource is a top level object defined by Redfish spec snd
     /// implements trait named IsResource. A resource should have @odata.type and @odata.id annotations as defined by the spec.
@@ -514,8 +757,12 @@ pub trait Redfish: Send + Sync + 'static {
     ///                              .and_then(|r| {r.try_get()})?;
     ///
     ///
-    fn get_resource<'a>(&'a self, id: ODataId)
-        -> RedfishFuture<'a, Result<Resource, RedfishError>>;
+    fn get_resource<'a>(
+        &'a self,
+        id: ODataId,
+    ) -> RedfishFuture<'a, Result<Resource, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_resource(self.std_redfish(), id)
+    }
 
     /// A kind-of-generic api to retrieve any resource. See get_resource() api for more details.
     /// This method returns Collection object that contains raw JSON and can be conveted to
@@ -539,7 +786,9 @@ pub trait Redfish: Send + Sync + 'static {
     fn get_collection<'a>(
         &'a self,
         id: ODataId,
-    ) -> RedfishFuture<'a, Result<Collection, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Collection, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_collection(self.std_redfish(), id)
+    }
 
     /// Change the boot order so the system will boot from the chosen NIC first.
     ///
@@ -551,103 +800,169 @@ pub trait Redfish: Send + Sync + 'static {
     fn set_boot_order_dpu_first<'a>(
         &'a self,
         boot_interface: BootInterfaceRef<'a>,
-    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_boot_order_dpu_first(
+            self.std_redfish(),
+            boot_interface,
+        )
+    }
 
     fn clear_uefi_password<'a>(
         &'a self,
         current_uefi_password: &'a str,
-    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::clear_uefi_password(
+            self.std_redfish(),
+            current_uefi_password,
+        )
+    }
 
-    fn get_update_service<'a>(&'a self) -> RedfishFuture<'a, Result<UpdateService, RedfishError>>;
+    fn get_update_service<'a>(&'a self) -> RedfishFuture<'a, Result<UpdateService, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_update_service(self.std_redfish())
+    }
 
     fn get_base_mac_address<'a>(
         &'a self,
-    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_base_mac_address(self.std_redfish())
+    }
 
     fn lockdown_bmc<'a>(
         &'a self,
         target: EnabledDisabled,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::lockdown_bmc(self.std_redfish(), target)
+    }
 
-    fn is_ipmi_over_lan_enabled<'a>(&'a self) -> RedfishFuture<'a, Result<bool, RedfishError>>;
+    fn is_ipmi_over_lan_enabled<'a>(&'a self) -> RedfishFuture<'a, Result<bool, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::is_ipmi_over_lan_enabled(self.std_redfish())
+    }
 
     fn enable_ipmi_over_lan<'a>(
         &'a self,
         target: EnabledDisabled,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::enable_ipmi_over_lan(self.std_redfish(), target)
+    }
 
-    fn enable_rshim_bmc<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn enable_rshim_bmc<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::enable_rshim_bmc(self.std_redfish())
+    }
 
     // Only applicable to Vikings
-    fn clear_nvram<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn clear_nvram<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::clear_nvram(self.std_redfish())
+    }
 
     // Only applicable to DPUs
-    fn get_nic_mode<'a>(&'a self) -> RedfishFuture<'a, Result<Option<NicMode>, RedfishError>>;
+    fn get_nic_mode<'a>(&'a self) -> RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_nic_mode(self.std_redfish())
+    }
 
     // Only applicable to DPUs
-    fn set_nic_mode<'a>(&'a self, mode: NicMode) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn set_nic_mode<'a>(&'a self, mode: NicMode) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_nic_mode(self.std_redfish(), mode)
+    }
 
     /// Enable infinite boot
-    fn enable_infinite_boot<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn enable_infinite_boot<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::enable_infinite_boot(self.std_redfish())
+    }
 
     /// Check if infinite boot is enabled
     fn is_infinite_boot_enabled<'a>(
         &'a self,
-    ) -> RedfishFuture<'a, Result<Option<bool>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::is_infinite_boot_enabled(self.std_redfish())
+    }
 
     // Only applicable to DPUs
     fn set_host_rshim<'a>(
         &'a self,
         enabled: EnabledDisabled,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_host_rshim(self.std_redfish(), enabled)
+    }
 
     // Only applicable to DPUs
     fn get_host_rshim<'a>(
         &'a self,
-    ) -> RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_host_rshim(self.std_redfish())
+    }
 
     // Only applicable to Dells
     fn set_idrac_lockdown<'a>(
         &'a self,
         enabled: EnabledDisabled,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_idrac_lockdown(self.std_redfish(), enabled)
+    }
 
     // Only applicable to Dells
-    fn get_boss_controller<'a>(&'a self)
-        -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    fn get_boss_controller<'a>(
+        &'a self,
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_boss_controller(self.std_redfish())
+    }
 
     // Only applicable to Dells
     fn decommission_storage_controller<'a>(
         &'a self,
         controller_id: &'a str,
-    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::decommission_storage_controller(
+            self.std_redfish(),
+            controller_id,
+        )
+    }
 
     // Only applicable to Dells
     fn create_storage_volume<'a>(
         &'a self,
         controller_id: &'a str,
         volume_name: &'a str,
-    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::create_storage_volume(
+            self.std_redfish(),
+            controller_id,
+            volume_name,
+        )
+    }
 
-    fn ac_powercycle_supported_by_power(&self) -> bool;
+    fn ac_powercycle_supported_by_power(&self) -> bool {
+        <standard::RedfishStandard as Redfish>::ac_powercycle_supported_by_power(self.std_redfish())
+    }
 
     /// Is the boot order already configured for `boot_interface`? See
     /// `set_boot_order_dpu_first` for the variant semantics.
     fn is_boot_order_setup<'a>(
         &'a self,
         boot_interface: BootInterfaceRef<'a>,
-    ) -> RedfishFuture<'a, Result<bool, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<bool, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::is_boot_order_setup(
+            self.std_redfish(),
+            boot_interface,
+        )
+    }
 
     /// Returns info about component integrity
     fn get_component_integrities<'a>(
         &'a self,
-    ) -> RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_component_integrities(self.std_redfish())
+    }
 
     /// Returns info about component integrity
     fn get_firmware_for_component<'a>(
         &'a self,
         component_integrity_id: &'a str,
-    ) -> RedfishFuture<'a, Result<SoftwareInventory, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<SoftwareInventory, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_firmware_for_component(
+            self.std_redfish(),
+            component_integrity_id,
+        )
+    }
 
     /// Component/evidence apis are taking URL as of now since not sure if all vendors keep
     /// certificate and evidence in chassis/same place. Once tested with all vendors, the url can
@@ -656,37 +971,59 @@ pub trait Redfish: Send + Sync + 'static {
     fn get_component_ca_certificate<'a>(
         &'a self,
         url: &'a str,
-    ) -> RedfishFuture<'a, Result<model::component_integrity::CaCertificate, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<model::component_integrity::CaCertificate, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_component_ca_certificate(
+            self.std_redfish(),
+            url,
+        )
+    }
 
     /// Trigger evidence collection
     fn trigger_evidence_collection<'a>(
         &'a self,
         url: &'a str,
         nonce: &'a str,
-    ) -> RedfishFuture<'a, Result<Task, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Task, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::trigger_evidence_collection(
+            self.std_redfish(),
+            url,
+            nonce,
+        )
+    }
 
     /// Fetches component certificate
     fn get_evidence<'a>(
         &'a self,
         url: &'a str,
-    ) -> RedfishFuture<'a, Result<model::component_integrity::Evidence, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<model::component_integrity::Evidence, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_evidence(self.std_redfish(), url)
+    }
 
     // Sets the host privilege level for a DPU
     fn set_host_privilege_level<'a>(
         &'a self,
         level: HostPrivilegeLevel,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_host_privilege_level(self.std_redfish(), level)
+    }
 
     // Sets the timezone to UTC
     // Only applicable to Dells
-    fn set_utc_timezone<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    fn set_utc_timezone<'a>(&'a self) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_utc_timezone(self.std_redfish())
+    }
 
     // Gets Oem.Nvidia.EastWestControlEnabled from a single CX NIC Settings
     // Only applicable to Vera-Rubin. `nic_index` must be in 0..8.
     fn get_spx_nic_east_west_control_enabled<'a>(
         &'a self,
         nic_index: u8,
-    ) -> RedfishFuture<'a, Result<Option<bool>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_spx_nic_east_west_control_enabled(
+            self.std_redfish(),
+            nic_index,
+        )
+    }
 
     // Sets Oem.Nvidia.EastWestControlEnabled on a single CX NIC Settings
     // Only applicable to Vera-Rubin. `nic_index` must be in 0..8.
@@ -694,27 +1031,45 @@ pub trait Redfish: Send + Sync + 'static {
         &'a self,
         nic_index: u8,
         enabled: bool,
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_spx_nic_east_west_control_enabled(
+            self.std_redfish(),
+            nic_index,
+            enabled,
+        )
+    }
 
     // Gets MAC address for a single CX_NIC_{nic_index}_Port_0 EthernetInterface
     // Only applicable to Vera-Rubin. `nic_index` must be in 0..8.
     fn get_spx_nic_mac_address<'a>(
         &'a self,
         nic_index: u8,
-    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<String>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_spx_nic_mac_address(
+            self.std_redfish(),
+            nic_index,
+        )
+    }
 
     // Gets Model and Name from Chassis/CX_{nic_index}
     // Only applicable to Vera-Rubin. `nic_index` must be in 0..8.
     fn get_spx_nic_model_and_name<'a>(
         &'a self,
         nic_index: u8,
-    ) -> RedfishFuture<'a, Result<Option<SpxNicModelAndName>, RedfishError>>;
+    ) -> RedfishFuture<'a, Result<Option<SpxNicModelAndName>, RedfishError>> {
+        <standard::RedfishStandard as Redfish>::get_spx_nic_model_and_name(
+            self.std_redfish(),
+            nic_index,
+        )
+    }
 
     // Sets the NTP servers
     fn set_ntp_servers<'a>(
         &'a self,
         servers: &'a [String],
-    ) -> RedfishFuture<'a, Result<(), RedfishError>>;
+    ) -> RedfishFuture<'a, Result<(), RedfishError>> {
+        <standard::RedfishStandard as Redfish>::set_ntp_servers(self.std_redfish(), servers)
+    }
 }
 
 /// Model and Name from a Vera-Rubin CX NIC chassis (`Chassis/CX_{index}`).
@@ -984,6 +1339,22 @@ pub fn model_coerce(original: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct DefaultDelegatingRedfish {
+        standard: standard::RedfishStandard,
+    }
+
+    impl Redfish for DefaultDelegatingRedfish {
+        fn std_redfish(&self) -> &standard::RedfishStandard {
+            &self.standard
+        }
+    }
+
+    #[test]
+    fn redfish_implementation_only_requires_standard_redfish() {
+        fn assert_redfish<T: Redfish>() {}
+        assert_redfish::<DefaultDelegatingRedfish>();
+    }
 
     #[test]
     fn boot_interface_ref_mac_returns_inner() {

--- a/src/liteon_powershelf.rs
+++ b/src/liteon_powershelf.rs
@@ -2,28 +2,24 @@ use crate::Assembly;
 use std::{collections::HashMap, path::Path, time::Duration};
 use tokio::fs::File;
 
-use crate::model::account_service::ManagerAccount;
 use crate::model::boot::BootOverride;
 use crate::model::certificate::Certificate;
 use crate::model::component_integrity::ComponentIntegrities;
-use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
 use crate::model::power::Power;
 use crate::model::sensor::GPUSensors;
 use crate::model::service_root::RedfishVendor;
 use crate::model::task::Task;
-use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
+use crate::model::update_service::ComponentType;
+use crate::MachineSetupStatus;
 use crate::{
     model::{
         chassis::NetworkAdapter,
         sel::{LogEntry, LogEntryCollection},
-        service_root::ServiceRoot,
-        storage::Drives,
-        BootOption, ComputerSystem, Manager,
+        BootOption, ComputerSystem,
     },
     standard::RedfishStandard,
-    BiosProfileType, Collection, NetworkDeviceFunction, ODataId, Redfish, RedfishError, Resource,
+    BiosProfileType, NetworkDeviceFunction, Redfish, RedfishError,
 };
-use crate::{EnabledDisabled, JobState, MachineSetupStatus, RoleId};
 
 const UEFI_PASSWORD_NAME: &str = "AdminPassword";
 
@@ -37,80 +33,9 @@ impl Bmc {
     }
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
-    /// Note that GH200 account_ids are not numbers but usernames: "root", "admin", etc
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
     fn get_power_state<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::PowerState, RedfishError>> {
@@ -126,28 +51,6 @@ impl Redfish for Bmc {
         // Discover the chassis carrying the PowerSubsystem rather than
         // hard-coding the Lite-On-specific id.
         Box::pin(async move { self.s.get_power_metrics_from_power_subsystem().await })
-    }
-
-    fn power<'a>(
-        &'a self,
-        action: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.power(action).await })
-    }
-
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
     }
 
     fn get_thermal_metrics<'a>(
@@ -170,19 +73,6 @@ impl Redfish for Bmc {
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
         Box::pin(async move { self.get_system_event_log().await })
-    }
-
-    fn get_bmc_event_log<'a>(
-        &'a self,
-        from: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_bmc_event_log(from).await })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
     }
 
     fn machine_setup<'a>(
@@ -248,22 +138,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn lockdown_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.lockdown_status().await })
-    }
-
-    fn setup_serial_console<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.setup_serial_console().await })
-    }
-
-    fn serial_console_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.serial_console_status().await })
-    }
-
     fn get_boot_options<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::BootOptions, RedfishError>> {
@@ -318,10 +192,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_tpm().await })
-    }
-
     fn pcie_devices<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<crate::PCIeDevice>, RedfishError>> {
@@ -330,19 +200,6 @@ impl Redfish for Bmc {
                 "Lite-on powershelf doesn't have PCIeDevices tree".to_string(),
             ))
         })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
     }
 
     fn update_firmware_multipart<'a>(
@@ -391,41 +248,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.bios().await })
-    }
-
-    fn set_bios<'a>(
-        &'a self,
-        values: HashMap<String, serde_json::Value>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_bios(values).await })
-    }
-
-    fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.reset_bios().await })
-    }
-
-    /// lite-on powershelf has no bios attributes
-    fn pending<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.pending().await })
-    }
-
-    /// gh200 has no bios attributes
-    fn clear_pending<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_pending().await })
-    }
-
     fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
         Box::pin(async move {
             let mut system = self.s.get_system().await?;
@@ -433,20 +255,6 @@ impl Redfish for Bmc {
             system.power_state = power_state_from_psus(&power);
             Ok(system)
         })
-    }
-
-    fn get_secure_boot<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::secure_boot::SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
-    }
-
-    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_secure_boot().await })
-    }
-
-    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.disable_secure_boot().await })
     }
 
     fn add_secure_boot_certificate<'a>(
@@ -459,19 +267,6 @@ impl Redfish for Bmc {
                 "Lite-on powershelf secure boot unsupported".to_string(),
             ))
         })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
     }
 
     fn get_chassis_network_adapters<'a>(
@@ -495,34 +290,6 @@ impl Redfish for Bmc {
                 "Lite-on powershelf  doesn't have NetworkAdapters tree".to_string(),
             ))
         })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
     }
 
     fn get_system_ethernet_interfaces<'a>(
@@ -617,49 +384,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
     fn set_boot_order_dpu_first<'a>(
         &'a self,
         _boot_interface: crate::BootInterfaceRef<'a>,
@@ -676,117 +400,6 @@ impl Redfish for Bmc {
         current_uefi_password: &'a str,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
-    }
-
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
-    fn is_infinite_boot_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move { self.s.is_infinite_boot_enabled().await })
-    }
-
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
     }
 
     fn get_secure_boot_certificate<'a>(
@@ -873,61 +486,6 @@ impl Redfish for Bmc {
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
         Box::pin(async move { Err(RedfishError::NotSupported("not supported".to_string())) })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -27,14 +27,10 @@ use reqwest::StatusCode;
 use serde::Deserialize;
 use tokio::fs::File;
 
-use crate::model::account_service::ManagerAccount;
-use crate::model::certificate::Certificate;
-use crate::model::component_integrity::ComponentIntegrities;
 use crate::model::oem::nvidia_dpu::NicMode;
-use crate::model::sensor::GPUSensors;
 use crate::model::service_root::RedfishVendor;
 use crate::model::task::Task;
-use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
+use crate::model::update_service::ComponentType;
 use crate::Boot::UefiHttp;
 use crate::HostPrivilegeLevel::Restricted;
 use crate::InternalCPUModel::Embedded;
@@ -44,17 +40,14 @@ use crate::{
             BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
             BootSourceOverrideTarget,
         },
-        chassis::{Assembly, NetworkAdapter},
         oem::nvidia_dpu::{HostPrivilegeLevel, InternalCPUModel},
         sel::{LogEntry, LogEntryCollection},
-        service_root::ServiceRoot,
-        storage::Drives,
-        BootOption, ComputerSystem, Manager,
+        BootOption,
     },
     standard::RedfishStandard,
-    BiosProfileType, Collection, NetworkDeviceFunction, ODataId, Redfish, RedfishError, Resource,
+    BiosProfileType, NetworkDeviceFunction, Redfish, RedfishError,
 };
-use crate::{EnabledDisabled, JobState, MachineSetupDiff, MachineSetupStatus, RoleId};
+use crate::{EnabledDisabled, MachineSetupDiff, MachineSetupStatus};
 
 pub struct Bmc {
     s: RedfishStandard,
@@ -81,86 +74,9 @@ impl Bmc {
     }
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
-    /// Note that DPU account_ids are not numbers but usernames: "root", "admin", etc
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_power_state<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
-    }
-
     fn get_power_metrics<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::Power, RedfishError>> {
@@ -170,30 +86,8 @@ impl Redfish for Bmc {
         })
     }
 
-    fn power<'a>(
-        &'a self,
-        action: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.power(action).await })
-    }
-
     fn ac_powercycle_supported_by_power(&self) -> bool {
         false
-    }
-
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
     }
 
     fn get_thermal_metrics<'a>(
@@ -203,12 +97,6 @@ impl Redfish for Bmc {
             let (_status_code, body) = self.s.client.get("Chassis/Card1/Thermal/").await?;
             Ok(body)
         })
-    }
-
-    fn get_gpu_sensors<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<GPUSensors>, RedfishError>> {
-        Box::pin(async move { self.s.get_gpu_sensors().await })
     }
 
     fn get_system_event_log<'a>(
@@ -228,12 +116,6 @@ impl Redfish for Bmc {
             );
             self.s.fetch_bmc_event_log(url, from).await
         })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
     }
 
     fn machine_setup<'a>(
@@ -340,42 +222,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn lockdown<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown(target).await })
-    }
-
-    fn lockdown_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.lockdown_status().await })
-    }
-
-    fn setup_serial_console<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.setup_serial_console().await })
-    }
-
-    fn serial_console_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.serial_console_status().await })
-    }
-
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
-    }
-
     fn boot_once<'a>(
         &'a self,
         target: crate::Boot,
@@ -445,29 +291,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_tpm().await })
-    }
-
-    fn pcie_devices<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<crate::PCIeDevice>, RedfishError>> {
-        Box::pin(async move { self.s.pcie_devices().await })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
-    }
-
     fn update_firmware_multipart<'a>(
         &'a self,
         filename: &'a Path,
@@ -524,22 +347,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.bios().await })
-    }
-
-    fn set_bios<'a>(
-        &'a self,
-        values: HashMap<String, serde_json::Value>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_bios(values).await })
-    }
-
     fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let url = format!("Systems/{}/Bios/Settings", self.s.system_id());
@@ -555,125 +362,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn pending<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.pending().await })
-    }
-
-    fn clear_pending<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_pending().await })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_secure_boot<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::secure_boot::SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
-    }
-
-    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_secure_boot().await })
-    }
-
-    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.disable_secure_boot().await })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
-    fn get_chassis_assembly<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapters<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapters(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapter<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
-    }
-
-    fn get_system_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interfaces().await })
-    }
-
-    fn get_system_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interface(id).await })
-    }
-
     fn get_ports<'a>(
         &'a self,
         chassis_id: &'a str,
@@ -687,25 +375,6 @@ impl Redfish for Bmc {
             );
             self.s.get_members(&url).await
         })
-    }
-
-    fn get_secure_boot_certificate<'a>(
-        &'a self,
-        database_id: &'a str,
-        certificate_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_secure_boot_certificate(database_id, certificate_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot_certificates<'a>(
-        &'a self,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
     }
 
     fn get_port<'a>(
@@ -783,24 +452,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
     fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let url = format!(
@@ -811,27 +462,6 @@ impl Redfish for Bmc {
             arg.insert("ResetToDefaultsType", "ResetAll".to_string());
             self.s.client.post(&url, arg).await.map(|_resp| Ok(()))?
         })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
     }
 
     fn set_boot_order_dpu_first<'a>(
@@ -863,39 +493,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
     fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let data = HashMap::from([("BmcRShim", HashMap::from([("BmcRShimEnabled", true)]))]);
@@ -906,10 +503,6 @@ impl Redfish for Bmc {
                 .await
                 .map(|_status_code| Ok(()))?
         })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
     }
 
     fn get_nic_mode<'a>(
@@ -923,16 +516,6 @@ impl Redfish for Bmc {
         mode: NicMode,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.set_nic_mode(mode).await })
-    }
-
-    fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_infinite_boot().await })
-    }
-
-    fn is_infinite_boot_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move { self.s.is_infinite_boot_enabled().await })
     }
 
     fn set_host_rshim<'a>(
@@ -977,45 +560,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
-    }
-
-    fn is_boot_order_setup<'a>(
-        &'a self,
-        boot_interface: crate::BootInterfaceRef<'a>,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_boot_order_setup(boot_interface).await })
-    }
-
     fn is_bios_setup<'a>(
         &'a self,
         boot_interface: Option<crate::BootInterfaceRef<'a>>,
@@ -1024,52 +568,6 @@ impl Redfish for Bmc {
             let status = self.machine_setup_status(boot_interface).await?;
             Ok(status.is_done)
         })
-    }
-
-    fn get_component_integrities<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
-        Box::pin(async move { self.s.get_component_integrities().await })
-    }
-
-    fn get_firmware_for_component<'a>(
-        &'a self,
-        componnent_integrity_id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move {
-            self.s
-                .get_firmware_for_component(componnent_integrity_id)
-                .await
-        })
-    }
-
-    fn get_component_ca_certificate<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
-    }
-
-    fn trigger_evidence_collection<'a>(
-        &'a self,
-        url: &'a str,
-        nonce: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
-    }
-
-    fn get_evidence<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
-    {
-        Box::pin(async move { self.s.get_evidence(url).await })
     }
 
     fn set_host_privilege_level<'a>(
@@ -1099,54 +597,6 @@ impl Redfish for Bmc {
                 .await
                 .map(|_status_code| Ok(()))?
         })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 

--- a/src/nvidia_gbswitch.rs
+++ b/src/nvidia_gbswitch.rs
@@ -1,15 +1,13 @@
 use reqwest::StatusCode;
 use std::{collections::HashMap, path::Path, time::Duration};
 
-use crate::model::account_service::ManagerAccount;
 use crate::model::certificate::Certificate;
 use crate::model::component_integrity::ComponentIntegrities;
-use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
 use crate::model::sensor::{GPUSensors, Sensors};
 use crate::model::service_root::RedfishVendor;
 use crate::model::task::Task;
 use crate::model::thermal::{LeakDetector, Temperature, TemperaturesOemNvidia, Thermal};
-use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
+use crate::model::update_service::ComponentType;
 use crate::model::PCIeDevices;
 use crate::REDFISH_ENDPOINT;
 use crate::{
@@ -17,15 +15,12 @@ use crate::{
         boot::{BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
         chassis::{Assembly, NetworkAdapter},
         sel::{LogEntry, LogEntryCollection},
-        service_root::ServiceRoot,
-        storage::Drives,
-        BootOption, ComputerSystem, Manager,
+        BootOption,
     },
     standard::RedfishStandard,
-    BiosProfileType, Chassis, Collection, NetworkDeviceFunction, ODataId, Redfish, RedfishError,
-    Resource,
+    BiosProfileType, Chassis, NetworkDeviceFunction, Redfish, RedfishError,
 };
-use crate::{EnabledDisabled, JobState, MachineSetupStatus, PCIeDevice, RoleId};
+use crate::{MachineSetupStatus, PCIeDevice};
 
 const UEFI_PASSWORD_NAME: &str = "AdminPassword";
 
@@ -61,86 +56,9 @@ enum BootOptionMatchField {
     UefiDevicePath,
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
-    /// Note that GH200 account_ids are not numbers but usernames: "root", "admin", etc
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_power_state<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
-    }
-
     fn get_power_metrics<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::Power, RedfishError>> {
@@ -149,28 +67,6 @@ impl Redfish for Bmc {
                 "GH200 PowerSubsystem not populated".to_string(),
             ))
         })
-    }
-
-    fn power<'a>(
-        &'a self,
-        action: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.power(action).await })
-    }
-
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
     }
 
     fn get_thermal_metrics<'a>(
@@ -247,19 +143,6 @@ impl Redfish for Bmc {
         Box::pin(async move { self.get_system_event_log().await })
     }
 
-    fn get_bmc_event_log<'a>(
-        &'a self,
-        from: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_bmc_event_log(from).await })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
-    }
-
     fn machine_setup<'a>(
         &'a self,
         _boot_interface: Option<crate::BootInterfaceRef<'a>>,
@@ -319,35 +202,6 @@ impl Redfish for Bmc {
             // carbide calls this so don't return an error, otherwise GH200 would need special handling
             Ok(())
         })
-    }
-
-    fn lockdown_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.lockdown_status().await })
-    }
-
-    fn setup_serial_console<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.setup_serial_console().await })
-    }
-
-    fn serial_console_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.serial_console_status().await })
-    }
-
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
     }
 
     fn boot_once<'a>(
@@ -431,10 +285,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_tpm().await })
-    }
-
     fn pcie_devices<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<PCIeDevice>, RedfishError>> {
@@ -483,19 +333,6 @@ impl Redfish for Bmc {
             out.sort_unstable_by(|a, b| a.manufacturer.cmp(&b.manufacturer));
             Ok(out)
         })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
     }
 
     fn update_firmware_multipart<'a>(
@@ -567,10 +404,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
     fn get_secure_boot<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::model::secure_boot::SecureBoot, RedfishError>> {
@@ -609,19 +442,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
     fn get_chassis_network_adapters<'a>(
         &'a self,
         _chassis_id: &'a str,
@@ -643,34 +463,6 @@ impl Redfish for Bmc {
                 "GB Switch doesn't have NetworkAdapters tree".to_string(),
             ))
         })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
     }
 
     fn get_system_ethernet_interfaces<'a>(
@@ -766,49 +558,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
     fn set_boot_order_dpu_first<'a>(
         &'a self,
         _boot_interface: crate::BootInterfaceRef<'a>,
@@ -825,117 +574,6 @@ impl Redfish for Bmc {
         current_uefi_password: &'a str,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
-    }
-
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
-    fn is_infinite_boot_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move { self.s.is_infinite_boot_enabled().await })
-    }
-
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
     }
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
@@ -1066,61 +704,6 @@ impl Redfish for Bmc {
                 "not populated for GBSwitch".to_string(),
             ))
         })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 

--- a/src/nvidia_gbx00.rs
+++ b/src/nvidia_gbx00.rs
@@ -29,32 +29,26 @@ use std::sync::OnceLock;
 use std::{collections::HashMap, path::Path, time::Duration};
 use tokio::fs::File;
 
-use crate::model::account_service::ManagerAccount;
-use crate::model::certificate::Certificate;
-use crate::model::component_integrity::{ComponentIntegrities, RegexToFirmwareIdOptions};
-use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
+use crate::model::component_integrity::RegexToFirmwareIdOptions;
 use crate::model::sensor::{GPUSensors, Sensor, Sensors};
 use crate::model::service_root::RedfishVendor;
 use crate::model::storage::DriveCollection;
 use crate::model::task::Task;
 use crate::model::thermal::Fan;
-use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
+use crate::model::update_service::ComponentType;
 use crate::{
     jsonmap,
     model::{
         boot::{BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
-        chassis::{Assembly, NetworkAdapter},
         power::{Power, PowerSupply, Voltages},
         sel::{LogEntry, LogEntryCollection},
-        service_root::ServiceRoot,
-        storage::Drives,
         thermal::{LeakDetector, Temperature, TemperaturesOemNvidia, Thermal},
-        BootOption, ComputerSystem, Manager,
+        BootOption, ComputerSystem,
     },
     standard::RedfishStandard,
-    BiosProfileType, Collection, NetworkDeviceFunction, ODataId, Redfish, RedfishError, Resource,
+    BiosProfileType, NetworkDeviceFunction, ODataId, Redfish, RedfishError,
 };
-use crate::{JobState, MachineSetupDiff, MachineSetupStatus, RoleId};
+use crate::{MachineSetupDiff, MachineSetupStatus};
 
 const UEFI_PASSWORD_NAME: &str = "AdminPassword";
 
@@ -140,52 +134,9 @@ fn get_component_integrity_id_to_firmware_inventory_id_options(
     })
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
     fn get_firmware<'a>(
         &'a self,
         id: &'a str,
@@ -203,29 +154,6 @@ impl Redfish for Bmc {
             });
             Ok(inv)
         })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_power_state<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
     }
 
     fn get_power_metrics<'a>(
@@ -346,21 +274,6 @@ impl Redfish for Bmc {
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
         true
-    }
-
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
     }
 
     fn get_thermal_metrics<'a>(
@@ -524,12 +437,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
-    }
-
     fn machine_setup<'a>(
         &'a self,
         _boot_interface: Option<crate::BootInterfaceRef<'a>>,
@@ -641,35 +548,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn lockdown_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.lockdown_status().await })
-    }
-
-    fn setup_serial_console<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.setup_serial_console().await })
-    }
-
-    fn serial_console_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.serial_console_status().await })
-    }
-
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
-    }
-
     fn boot_once<'a>(
         &'a self,
         target: crate::Boot,
@@ -751,29 +629,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_tpm().await })
-    }
-
-    fn pcie_devices<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<crate::PCIeDevice>, RedfishError>> {
-        Box::pin(async move { self.s.pcie_devices().await })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
-    }
-
     fn update_firmware_multipart<'a>(
         &'a self,
         filename: &'a Path,
@@ -825,47 +680,8 @@ impl Redfish for Bmc {
         })
     }
 
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.bios().await })
-    }
-
-    fn set_bios<'a>(
-        &'a self,
-        values: HashMap<String, serde_json::Value>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_bios(values).await })
-    }
-
     fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.factory_reset_bios().await })
-    }
-
-    fn pending<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.pending().await })
-    }
-
-    fn clear_pending<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_pending().await })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_secure_boot<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::secure_boot::SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
     }
 
     fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -888,100 +704,6 @@ impl Redfish for Bmc {
             }
             self.s.disable_secure_boot().await
         })
-    }
-
-    fn get_secure_boot_certificate<'a>(
-        &'a self,
-        database_id: &'a str,
-        certificate_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_secure_boot_certificate(database_id, certificate_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot_certificates<'a>(
-        &'a self,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
-    fn get_chassis_assembly<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapters<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapters(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapter<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
     }
 
     fn get_system_ethernet_interfaces<'a>(
@@ -1082,49 +804,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
     fn set_boot_order_dpu_first<'a>(
         &'a self,
         boot_interface: crate::BootInterfaceRef<'a>,
@@ -1151,66 +830,6 @@ impl Redfish for Bmc {
         current_uefi_password: &'a str,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
-    }
-
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
     }
 
     fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -1241,51 +860,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
-    }
-
     fn is_boot_order_setup<'a>(
         &'a self,
         boot_interface: crate::BootInterfaceRef<'a>,
@@ -1305,12 +879,6 @@ impl Redfish for Bmc {
             let diffs = self.diff_bios_bmc_attr().await?;
             Ok(diffs.is_empty())
         })
-    }
-
-    fn get_component_integrities<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
-        Box::pin(async move { self.s.get_component_integrities().await })
     }
 
     fn get_firmware_for_component<'a>(
@@ -1350,87 +918,6 @@ impl Redfish for Bmc {
             };
             self.get_firmware(&id).await
         })
-    }
-
-    fn get_component_ca_certificate<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
-    }
-
-    fn trigger_evidence_collection<'a>(
-        &'a self,
-        url: &'a str,
-        nonce: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
-    }
-
-    fn get_evidence<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
-    {
-        Box::pin(async move { self.s.get_evidence(url).await })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 

--- a/src/nvidia_gh200.rs
+++ b/src/nvidia_gh200.rs
@@ -2,28 +2,24 @@ use std::{collections::HashMap, path::Path, time::Duration};
 
 use tokio::fs::File;
 
-use crate::model::account_service::ManagerAccount;
 use crate::model::certificate::Certificate;
 use crate::model::component_integrity::ComponentIntegrities;
-use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
 use crate::model::sensor::GPUSensors;
 use crate::model::service_root::RedfishVendor;
 use crate::model::task::Task;
-use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
+use crate::model::update_service::ComponentType;
 use crate::Boot::UefiHttp;
 use crate::{
     model::{
         boot::{self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
         chassis::{Assembly, NetworkAdapter},
         sel::{LogEntry, LogEntryCollection},
-        service_root::ServiceRoot,
-        storage::Drives,
-        BootOption, ComputerSystem, Manager,
+        BootOption, ComputerSystem,
     },
     standard::RedfishStandard,
-    BiosProfileType, Collection, NetworkDeviceFunction, ODataId, Redfish, RedfishError, Resource,
+    BiosProfileType, NetworkDeviceFunction, Redfish, RedfishError,
 };
-use crate::{EnabledDisabled, JobState, MachineSetupDiff, MachineSetupStatus, RoleId};
+use crate::{MachineSetupDiff, MachineSetupStatus};
 
 const UEFI_PASSWORD_NAME: &str = "AdminPassword";
 
@@ -121,86 +117,9 @@ enum BootOptionMatchField {
     UefiDevicePath,
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
-    /// Note that GH200 account_ids are not numbers but usernames: "root", "admin", etc
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_power_state<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
-    }
-
     fn get_power_metrics<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::Power, RedfishError>> {
@@ -234,21 +153,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
-    }
-
     fn get_thermal_metrics<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::Thermal, RedfishError>> {
@@ -273,19 +177,6 @@ impl Redfish for Bmc {
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
         Box::pin(async move { self.get_system_event_log().await })
-    }
-
-    fn get_bmc_event_log<'a>(
-        &'a self,
-        from: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_bmc_event_log(from).await })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
     }
 
     fn machine_setup<'a>(
@@ -356,35 +247,6 @@ impl Redfish for Bmc {
             // carbide calls this so don't return an error, otherwise GH200 would need special handling
             Ok(())
         })
-    }
-
-    fn lockdown_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.lockdown_status().await })
-    }
-
-    fn setup_serial_console<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.setup_serial_console().await })
-    }
-
-    fn serial_console_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.serial_console_status().await })
-    }
-
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
     }
 
     fn boot_once<'a>(
@@ -468,10 +330,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_tpm().await })
-    }
-
     fn pcie_devices<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<crate::PCIeDevice>, RedfishError>> {
@@ -480,19 +338,6 @@ impl Redfish for Bmc {
                 "GH200 doesn't have PCIeDevices tree".to_string(),
             ))
         })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
     }
 
     fn update_firmware_multipart<'a>(
@@ -541,82 +386,8 @@ impl Redfish for Bmc {
         })
     }
 
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.bios().await })
-    }
-
-    fn set_bios<'a>(
-        &'a self,
-        values: HashMap<String, serde_json::Value>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_bios(values).await })
-    }
-
     fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.s.factory_reset_bios().await })
-    }
-
-    /// gh200 has no bios attributes
-    fn pending<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.pending().await })
-    }
-
-    /// gh200 has no bios attributes
-    fn clear_pending<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_pending().await })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_secure_boot<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::secure_boot::SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
-    }
-
-    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_secure_boot().await })
-    }
-
-    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.disable_secure_boot().await })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
     }
 
     fn get_chassis_network_adapters<'a>(
@@ -640,34 +411,6 @@ impl Redfish for Bmc {
                 "GH200 doesn't have NetworkAdapters tree".to_string(),
             ))
         })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
     }
 
     fn get_system_ethernet_interfaces<'a>(
@@ -763,49 +506,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
     fn set_boot_order_dpu_first<'a>(
         &'a self,
         boot_interface: crate::BootInterfaceRef<'a>,
@@ -840,117 +540,6 @@ impl Redfish for Bmc {
         current_uefi_password: &'a str,
     ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
-    }
-
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
-    fn is_infinite_boot_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move { self.s.is_infinite_boot_enabled().await })
-    }
-
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
     }
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
@@ -1079,61 +668,6 @@ impl Redfish for Bmc {
                 "not populated for GH200".to_string(),
             ))
         })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 

--- a/src/nvidia_vera_rubin.rs
+++ b/src/nvidia_vera_rubin.rs
@@ -30,32 +30,26 @@ use std::sync::OnceLock;
 use std::{collections::HashMap, path::Path, time::Duration};
 use tokio::fs::File;
 
-use crate::model::account_service::ManagerAccount;
-use crate::model::certificate::Certificate;
-use crate::model::component_integrity::{ComponentIntegrities, RegexToFirmwareIdOptions};
-use crate::model::oem::nvidia_dpu::{HostPrivilegeLevel, NicMode};
+use crate::model::component_integrity::RegexToFirmwareIdOptions;
 use crate::model::sensor::{GPUSensors, Sensor, Sensors};
 use crate::model::service_root::RedfishVendor;
 use crate::model::storage::DriveCollection;
 use crate::model::task::Task;
 use crate::model::thermal::Fan;
-use crate::model::update_service::{ComponentType, TransferProtocolType, UpdateService};
+use crate::model::update_service::ComponentType;
 use crate::{
     jsonmap,
     model::{
         boot::{BootOverride, BootSourceOverrideEnabled, BootSourceOverrideTarget},
-        chassis::{Assembly, NetworkAdapter},
         power::{Power, PowerSupply, Voltages},
         sel::{LogEntry, LogEntryCollection},
-        service_root::ServiceRoot,
-        storage::Drives,
         thermal::{LeakDetector, Temperature, TemperaturesOemNvidia, Thermal},
-        BootOption, ComputerSystem, Manager,
+        BootOption,
     },
     standard::RedfishStandard,
-    BiosProfileType, Collection, NetworkDeviceFunction, ODataId, Redfish, RedfishError, Resource,
+    BiosProfileType, NetworkDeviceFunction, Redfish, RedfishError,
 };
-use crate::{JobState, MachineSetupDiff, MachineSetupStatus, RoleId};
+use crate::{MachineSetupDiff, MachineSetupStatus};
 
 const UEFI_PASSWORD_NAME: &str = "AdminPassword";
 
@@ -150,52 +144,9 @@ fn get_component_integrity_id_to_firmware_inventory_id_options(
     })
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
     fn get_firmware<'a>(
         &'a self,
         id: &'a str,
@@ -213,29 +164,6 @@ impl Redfish for Bmc {
             });
             Ok(inv)
         })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_power_state<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
     }
 
     fn get_power_metrics<'a>(
@@ -356,21 +284,6 @@ impl Redfish for Bmc {
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
         true
-    }
-
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: crate::SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
     }
 
     fn get_thermal_metrics<'a>(
@@ -521,19 +434,6 @@ impl Redfish for Bmc {
         Box::pin(async move { self.get_system_event_log().await })
     }
 
-    fn get_bmc_event_log<'a>(
-        &'a self,
-        from: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_bmc_event_log(from).await })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
-    }
-
     fn machine_setup<'a>(
         &'a self,
         _boot_interface: Option<crate::BootInterfaceRef<'a>>,
@@ -639,35 +539,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn lockdown_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.lockdown_status().await })
-    }
-
-    fn setup_serial_console<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.setup_serial_console().await })
-    }
-
-    fn serial_console_status<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
-        Box::pin(async move { self.s.serial_console_status().await })
-    }
-
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
-    }
-
     fn boot_once<'a>(
         &'a self,
         target: crate::Boot,
@@ -749,29 +620,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn clear_tpm<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_tpm().await })
-    }
-
-    fn pcie_devices<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<crate::PCIeDevice>, RedfishError>> {
-        Box::pin(async move { self.s.pcie_devices().await })
-    }
-
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
-    }
-
     fn update_firmware_multipart<'a>(
         &'a self,
         filename: &'a Path,
@@ -821,151 +669,6 @@ impl Redfish for Bmc {
 
             Ok(task.id)
         })
-    }
-
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.bios().await })
-    }
-
-    fn set_bios<'a>(
-        &'a self,
-        values: HashMap<String, serde_json::Value>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_bios(values).await })
-    }
-
-    fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.reset_bios().await })
-    }
-
-    fn pending<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<std::collections::HashMap<String, serde_json::Value>, RedfishError>,
-    > {
-        Box::pin(async move { self.s.pending().await })
-    }
-
-    fn clear_pending<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_pending().await })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_secure_boot<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::secure_boot::SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
-    }
-
-    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_secure_boot().await })
-    }
-
-    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.disable_secure_boot().await })
-    }
-
-    fn get_secure_boot_certificate<'a>(
-        &'a self,
-        database_id: &'a str,
-        certificate_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_secure_boot_certificate(database_id, certificate_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot_certificates<'a>(
-        &'a self,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
-    fn get_chassis_assembly<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapters<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapters(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapter<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
     }
 
     fn get_system_ethernet_interfaces<'a>(
@@ -1066,49 +769,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
     fn set_boot_order_dpu_first<'a>(
         &'a self,
         boot_interface: crate::BootInterfaceRef<'a>,
@@ -1155,66 +815,6 @@ impl Redfish for Bmc {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
     }
 
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
     fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let attrs: HashMap<String, serde_json::Value> =
@@ -1232,51 +832,6 @@ impl Redfish for Bmc {
             let embedded_uefi_shell = self.get_embedded_uefi_shell_status().await?;
             // Infinite boot is enabled when EmbeddedUefiShell is disabled
             Ok(Some(embedded_uefi_shell == EnabledDisabled::Disabled))
-        })
-    }
-
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
         })
     }
 
@@ -1299,12 +854,6 @@ impl Redfish for Bmc {
             let diffs = self.diff_bios_bmc_attr().await?;
             Ok(diffs.is_empty())
         })
-    }
-
-    fn get_component_integrities<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
-        Box::pin(async move { self.s.get_component_integrities().await })
     }
 
     fn get_firmware_for_component<'a>(
@@ -1344,43 +893,6 @@ impl Redfish for Bmc {
             };
             self.get_firmware(&id).await
         })
-    }
-
-    fn get_component_ca_certificate<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
-    }
-
-    fn trigger_evidence_collection<'a>(
-        &'a self,
-        url: &'a str,
-        nonce: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
-    }
-
-    fn get_evidence<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
-    {
-        Box::pin(async move { self.s.get_evidence(url).await })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
     }
 
     // Get the EastWestControlEnabled attribute for the CX NIC with the given index
@@ -1480,13 +992,6 @@ impl Redfish for Bmc {
             })?;
             Ok(Some(crate::SpxNicModelAndName { model, name }))
         })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 

--- a/src/nvidia_viking.rs
+++ b/src/nvidia_viking.rs
@@ -32,40 +32,26 @@ use version_compare::Version;
 
 use crate::{
     model::{
-        account_service::ManagerAccount,
         boot::{
             BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode,
             BootSourceOverrideTarget,
         },
-        certificate::Certificate,
-        chassis::{Assembly, Chassis, NetworkAdapter},
-        component_integrity::ComponentIntegrities,
-        network_device_function::NetworkDeviceFunction,
-        oem::{
-            nvidia_dpu::{HostPrivilegeLevel, NicMode},
-            nvidia_viking::{
-                BootDevices::{self},
-                *,
-            },
+        oem::nvidia_viking::{
+            BootDevices::{self},
+            *,
         },
-        power::Power,
         resource::IsResource,
-        secure_boot::SecureBoot,
         sel::{LogEntry, LogEntryCollection},
         sensor::{GPUSensors, Sensor},
-        service_root::{RedfishVendor, ServiceRoot},
-        software_inventory::SoftwareInventory,
-        storage::Drives,
-        task::Task,
-        thermal::Thermal,
-        update_service::{ComponentType, TransferProtocolType, UpdateService},
-        BootOption, ComputerSystem, EnableDisable, Manager, ManagerResetType,
+        service_root::RedfishVendor,
+        update_service::ComponentType,
+        BootOption, ComputerSystem, EnableDisable, ManagerResetType,
     },
     standard::RedfishStandard,
-    BiosProfileType, Boot, BootOptions, Collection,
+    BiosProfileType, Boot,
     EnabledDisabled::{self, Disabled, Enabled},
-    JobState, MachineSetupDiff, MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish,
-    RedfishError, Resource, RoleId, Status, StatusInternal, SystemPowerControl,
+    MachineSetupDiff, MachineSetupStatus, PCIeDevice, Redfish, RedfishError, Status,
+    StatusInternal,
 };
 
 const UEFI_PASSWORD_NAME: &str = "AdminPassword";
@@ -80,38 +66,9 @@ impl Bmc {
     }
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        user: &'a str,
-        new: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(user, new).await })
-    }
-
     /*
         https://docs.nvidia.com/dgx/dgxh100-user-guide/redfish-api-supp.html
         curl -k -u <bmc-user>:<password> --request PATCH 'https://<bmc-ip-address>/redfish/v1/AccountService/Accounts/2' --header 'If-Match: *'  --header 'Content-Type: application/json' --data-raw '{ "Password" : "<password>" }'
@@ -127,27 +84,6 @@ impl Redfish for Bmc {
             data.insert("Password", new_pass);
             self.s.client.patch_with_if_match(&url, data).await
         })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_power_state<'a>(&'a self) -> crate::RedfishFuture<'a, Result<PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
-    }
-
-    fn get_power_metrics<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Power, RedfishError>> {
-        Box::pin(async move { self.s.get_power_metrics().await })
-    }
-
-    fn power<'a>(
-        &'a self,
-        action: SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.power(action).await })
     }
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
@@ -166,20 +102,6 @@ impl Redfish for Bmc {
                 )
                 .await
         })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
-    }
-
-    fn get_thermal_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Thermal, RedfishError>> {
-        Box::pin(async move { self.s.get_thermal_metrics().await })
     }
 
     fn get_gpu_sensors<'a>(
@@ -214,32 +136,6 @@ impl Redfish for Bmc {
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
         Box::pin(async move { self.get_system_event_log().await })
-    }
-
-    fn get_bmc_event_log<'a>(
-        &'a self,
-        from: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_bmc_event_log(from).await })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
-    }
-
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>> {
-        Box::pin(async move { self.s.bios().await })
-    }
-
-    fn set_bios<'a>(
-        &'a self,
-        values: HashMap<String, serde_json::Value>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_bios(values).await })
     }
 
     fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -425,19 +321,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
-    }
-
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let override_target = match target {
@@ -583,13 +466,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
     /// update_firmware_multipart returns a string with the task ID
     fn update_firmware_multipart<'a>(
         &'a self,
@@ -633,30 +509,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<SoftwareInventory, RedfishError>> {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
     fn get_software_inventories<'a>(
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
@@ -668,45 +520,6 @@ impl Redfish for Bmc {
                 )
                 .await
         })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_secure_boot_certificate<'a>(
-        &'a self,
-        database_id: &'a str,
-        certificate_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_secure_boot_certificate(database_id, certificate_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot_certificates<'a>(
-        &'a self,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
     }
 
     fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -727,119 +540,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_network_device_function<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-        port: Option<&'a str>,
-    ) -> crate::RedfishFuture<'a, Result<NetworkDeviceFunction, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_network_device_function(chassis_id, id, port)
-                .await
-        })
-    }
-
-    fn get_network_device_functions<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_network_device_functions(chassis_id).await })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
-    fn get_chassis_assembly<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapters<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapters(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapter<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_ports<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_ports(chassis_id, network_adapter).await })
-    }
-
-    fn get_port<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::NetworkPort, RedfishError>> {
-        Box::pin(async move { self.s.get_port(chassis_id, network_adapter, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
-    }
-
-    fn get_system_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interfaces().await })
-    }
-
-    fn get_system_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interface(id).await })
-    }
-
     fn change_uefi_password<'a>(
         &'a self,
         current_uefi_password: &'a str,
@@ -857,55 +557,6 @@ impl Redfish for Bmc {
         boot_array: Vec<String>,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.change_boot_order_with_etag(boot_array, None).await })
-    }
-
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
-    }
-
-    fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset_to_defaults().await })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
-    }
-
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
     }
 
     //
@@ -1055,43 +706,6 @@ impl Redfish for Bmc {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
     }
 
-    fn lockdown_bmc<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.lockdown_bmc(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
     /***
          curl -k -u admin:admin
          --request POST
@@ -1119,19 +733,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
     fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
             let attrs = BiosAttributes {
@@ -1157,51 +758,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
-    }
-
     fn is_boot_order_setup<'a>(
         &'a self,
         boot_interface: crate::BootInterfaceRef<'a>,
@@ -1221,107 +777,6 @@ impl Redfish for Bmc {
             let diffs = self.diff_bios_bmc_attr().await?;
             Ok(diffs.is_empty())
         })
-    }
-
-    fn get_component_integrities<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
-        Box::pin(async move { self.s.get_component_integrities().await })
-    }
-
-    fn get_firmware_for_component<'a>(
-        &'a self,
-        componnent_integrity_id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move {
-            self.s
-                .get_firmware_for_component(componnent_integrity_id)
-                .await
-        })
-    }
-
-    fn get_component_ca_certificate<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
-    }
-
-    fn trigger_evidence_collection<'a>(
-        &'a self,
-        url: &'a str,
-        nonce: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
-    }
-
-    fn get_evidence<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
-    {
-        Box::pin(async move { self.s.get_evidence(url).await })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 

--- a/src/standard.rs
+++ b/src/standard.rs
@@ -72,6 +72,9 @@ pub struct RedfishStandard {
     service_root: ServiceRoot,
 }
 impl Redfish for RedfishStandard {
+    fn std_redfish(&self) -> &RedfishStandard {
+        self
+    }
     fn create_user<'a>(
         &'a self,
         username: &'a str,

--- a/src/supermicro.rs
+++ b/src/supermicro.rs
@@ -28,32 +28,17 @@ use tokio::fs::File;
 
 use crate::{
     model::{
-        account_service::ManagerAccount,
         boot::{self, BootOverride, BootSourceOverrideEnabled, BootSourceOverrideMode},
-        certificate::Certificate,
-        chassis::{Assembly, Chassis, NetworkAdapter},
-        component_integrity::ComponentIntegrities,
-        network_device_function::NetworkDeviceFunction,
-        oem::{
-            nvidia_dpu::{HostPrivilegeLevel, NicMode},
-            supermicro::{self, FixedBootOrder},
-        },
-        power::Power,
-        secure_boot::SecureBoot,
-        sel::LogEntry,
-        sensor::GPUSensors,
-        service_root::{RedfishVendor, ServiceRoot},
-        software_inventory::SoftwareInventory,
-        storage::Drives,
+        chassis::Chassis,
+        oem::supermicro::{self, FixedBootOrder},
+        service_root::RedfishVendor,
         task::Task,
-        thermal::Thermal,
-        update_service::{ComponentType, TransferProtocolType, UpdateService},
-        BootOption, ComputerSystem, EnableDisable, InvalidValueError, Manager,
+        update_service::ComponentType,
+        BootOption, EnableDisable, InvalidValueError,
     },
     standard::RedfishStandard,
-    BiosProfileType, Boot, BootOptions, Collection, EnabledDisabled, JobState, MachineSetupDiff,
-    MachineSetupStatus, ODataId, PCIeDevice, PowerState, Redfish, RedfishError, Resource, RoleId,
-    Status, StatusInternal, SystemPowerControl,
+    BiosProfileType, Boot, EnabledDisabled, MachineSetupDiff, MachineSetupStatus, ODataId,
+    PCIeDevice, Redfish, RedfishError, Status, StatusInternal, SystemPowerControl,
 };
 
 const MELLANOX_UEFI_HTTP_IPV4: &str = "UEFI HTTP IPv4 Mellanox Network Adapter";
@@ -168,60 +153,9 @@ impl Bmc {
     }
 }
 impl Redfish for Bmc {
-    fn create_user<'a>(
-        &'a self,
-        username: &'a str,
-        password: &'a str,
-        role_id: RoleId,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.create_user(username, password, role_id).await })
+    fn std_redfish(&self) -> &RedfishStandard {
+        &self.s
     }
-
-    fn delete_user<'a>(
-        &'a self,
-        username: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.delete_user(username).await })
-    }
-
-    fn change_username<'a>(
-        &'a self,
-        old_name: &'a str,
-        new_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_username(old_name, new_name).await })
-    }
-
-    fn change_password<'a>(
-        &'a self,
-        username: &'a str,
-        new_password: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password(username, new_password).await })
-    }
-
-    fn change_password_by_id<'a>(
-        &'a self,
-        account_id: &'a str,
-        new_pass: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.change_password_by_id(account_id, new_pass).await })
-    }
-
-    fn get_accounts<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<ManagerAccount>, RedfishError>> {
-        Box::pin(async move { self.s.get_accounts().await })
-    }
-
-    fn get_power_state<'a>(&'a self) -> crate::RedfishFuture<'a, Result<PowerState, RedfishError>> {
-        Box::pin(async move { self.s.get_power_state().await })
-    }
-
-    fn get_power_metrics<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Power, RedfishError>> {
-        Box::pin(async move { self.s.get_power_metrics().await })
-    }
-
     fn power<'a>(
         &'a self,
         action: SystemPowerControl,
@@ -242,65 +176,6 @@ impl Redfish for Bmc {
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
         true
-    }
-
-    fn bmc_reset<'a>(
-        &'a self,
-        reset_type: Option<crate::ManagerResetType>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.bmc_reset(reset_type).await })
-    }
-
-    fn chassis_reset<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        reset_type: SystemPowerControl,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.chassis_reset(chassis_id, reset_type).await })
-    }
-
-    fn get_thermal_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Thermal, RedfishError>> {
-        Box::pin(async move { self.s.get_thermal_metrics().await })
-    }
-
-    fn get_gpu_sensors<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<GPUSensors>, RedfishError>> {
-        Box::pin(async move { self.s.get_gpu_sensors().await })
-    }
-
-    fn get_system_event_log<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_system_event_log().await })
-    }
-
-    fn get_bmc_event_log<'a>(
-        &'a self,
-        from: Option<chrono::DateTime<chrono::Utc>>,
-    ) -> crate::RedfishFuture<'a, Result<Vec<LogEntry>, RedfishError>> {
-        Box::pin(async move { self.s.get_bmc_event_log(from).await })
-    }
-
-    fn get_drives_metrics<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<Drives>, RedfishError>> {
-        Box::pin(async move { self.s.get_drives_metrics().await })
-    }
-
-    fn bios<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>> {
-        Box::pin(async move { self.s.bios().await })
-    }
-
-    fn set_bios<'a>(
-        &'a self,
-        values: HashMap<String, serde_json::Value>,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_bios(values).await })
     }
 
     fn reset_bios<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -486,19 +361,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_boot_options<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<BootOptions, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_options().await })
-    }
-
-    fn get_boot_option<'a>(
-        &'a self,
-        option_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<BootOption, RedfishError>> {
-        Box::pin(async move { self.s.get_boot_option(option_id).await })
-    }
-
     /// Boot from this device once then go back to the normal boot order
     fn boot_once<'a>(&'a self, target: Boot) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move {
@@ -642,13 +504,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn update_firmware<'a>(
-        &'a self,
-        firmware: tokio::fs::File,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.update_firmware(firmware).await })
-    }
-
     fn update_firmware_multipart<'a>(
         &'a self,
         filename: &'a Path,
@@ -699,208 +554,6 @@ impl Redfish for Bmc {
         })
     }
 
-    fn get_update_service<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<UpdateService, RedfishError>> {
-        Box::pin(async move { self.s.get_update_service().await })
-    }
-
-    fn get_tasks<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_tasks().await })
-    }
-
-    fn get_task<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::task::Task, RedfishError>> {
-        Box::pin(async move { self.s.get_task(id).await })
-    }
-
-    fn get_firmware<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<SoftwareInventory, RedfishError>> {
-        Box::pin(async move { self.s.get_firmware(id).await })
-    }
-
-    fn get_software_inventories<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_software_inventories().await })
-    }
-
-    fn get_system<'a>(&'a self) -> crate::RedfishFuture<'a, Result<ComputerSystem, RedfishError>> {
-        Box::pin(async move { self.s.get_system().await })
-    }
-
-    fn get_secure_boot_certificates<'a>(
-        &'a self,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot_certificates(database_id).await })
-    }
-
-    fn get_secure_boot_certificate<'a>(
-        &'a self,
-        database_id: &'a str,
-        certificate_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Certificate, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_secure_boot_certificate(database_id, certificate_id)
-                .await
-        })
-    }
-
-    fn add_secure_boot_certificate<'a>(
-        &'a self,
-        pem_cert: &'a str,
-        database_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .add_secure_boot_certificate(pem_cert, database_id)
-                .await
-        })
-    }
-
-    fn get_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<SecureBoot, RedfishError>> {
-        Box::pin(async move { self.s.get_secure_boot().await })
-    }
-
-    fn enable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_secure_boot().await })
-    }
-
-    fn disable_secure_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.disable_secure_boot().await })
-    }
-
-    fn get_network_device_function<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-        port: Option<&'a str>,
-    ) -> crate::RedfishFuture<'a, Result<NetworkDeviceFunction, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_network_device_function(chassis_id, id, port)
-                .await
-        })
-    }
-
-    fn get_network_device_functions<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_network_device_functions(chassis_id).await })
-    }
-
-    fn get_chassis_all<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_all().await })
-    }
-
-    fn get_chassis<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Chassis, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis(id).await })
-    }
-
-    fn get_chassis_assembly<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Assembly, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_assembly(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapters<'a>(
-        &'a self,
-        chassis_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapters(chassis_id).await })
-    }
-
-    fn get_chassis_network_adapter<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_chassis_network_adapter(chassis_id, id).await })
-    }
-
-    fn get_base_network_adapters<'a>(
-        &'a self,
-        system_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapters(system_id).await })
-    }
-
-    fn get_base_network_adapter<'a>(
-        &'a self,
-        system_id: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<NetworkAdapter, RedfishError>> {
-        Box::pin(async move { self.s.get_base_network_adapter(system_id, id).await })
-    }
-
-    fn get_ports<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_ports(chassis_id, network_adapter).await })
-    }
-
-    fn get_port<'a>(
-        &'a self,
-        chassis_id: &'a str,
-        network_adapter: &'a str,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::NetworkPort, RedfishError>> {
-        Box::pin(async move { self.s.get_port(chassis_id, network_adapter, id).await })
-    }
-
-    fn get_manager_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interfaces().await })
-    }
-
-    fn get_manager_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_manager_ethernet_interface(id).await })
-    }
-
-    fn get_system_ethernet_interfaces<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interfaces().await })
-    }
-
-    fn get_system_ethernet_interface<'a>(
-        &'a self,
-        id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::EthernetInterface, RedfishError>> {
-        Box::pin(async move { self.s.get_system_ethernet_interface(id).await })
-    }
-
-    fn change_uefi_password<'a>(
-        &'a self,
-        current_uefi_password: &'a str,
-        new_uefi_password: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .change_uefi_password(current_uefi_password, new_uefi_password)
-                .await
-        })
-    }
-
     fn change_boot_order<'a>(
         &'a self,
         boot_array: Vec<String>,
@@ -910,24 +563,6 @@ impl Redfish for Bmc {
             let url = format!("Systems/{}", self.s.system_id());
             self.s.client.patch(&url, body).await.map(|_status_code| ())
         })
-    }
-
-    fn get_service_root<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ServiceRoot, RedfishError>> {
-        Box::pin(async move { self.s.get_service_root().await })
-    }
-
-    fn get_systems<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_systems().await })
-    }
-
-    fn get_managers<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_managers().await })
-    }
-
-    fn get_manager<'a>(&'a self) -> crate::RedfishFuture<'a, Result<Manager, RedfishError>> {
-        Box::pin(async move { self.s.get_manager().await })
     }
 
     fn bmc_reset_to_defaults<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
@@ -945,27 +580,6 @@ impl Redfish for Bmc {
             arg.insert("Option", "ClearConfig".to_string());
             self.s.client.post(&url, arg).await.map(|_resp| ())
         })
-    }
-
-    fn get_job_state<'a>(
-        &'a self,
-        job_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<JobState, RedfishError>> {
-        Box::pin(async move { self.s.get_job_state(job_id).await })
-    }
-
-    fn get_collection<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Collection, RedfishError>> {
-        Box::pin(async move { self.s.get_collection(id).await })
-    }
-
-    fn get_resource<'a>(
-        &'a self,
-        id: ODataId,
-    ) -> crate::RedfishFuture<'a, Result<Resource, RedfishError>> {
-        Box::pin(async move { self.s.get_resource(id).await })
     }
 
     /// Set the DPU to be our first netboot device.
@@ -1062,119 +676,11 @@ impl Redfish for Bmc {
         Box::pin(async move { self.change_uefi_password(current_uefi_password, "").await })
     }
 
-    fn get_base_mac_address<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_base_mac_address().await })
-    }
-
     fn lockdown_bmc<'a>(
         &'a self,
         target: crate::EnabledDisabled,
     ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
         Box::pin(async move { self.set_syslockdown(target).await })
-    }
-
-    fn is_ipmi_over_lan_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<bool, RedfishError>> {
-        Box::pin(async move { self.s.is_ipmi_over_lan_enabled().await })
-    }
-
-    fn enable_ipmi_over_lan<'a>(
-        &'a self,
-        target: crate::EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_ipmi_over_lan(target).await })
-    }
-
-    fn update_firmware_simple_update<'a>(
-        &'a self,
-        image_uri: &'a str,
-        targets: Vec<String>,
-        transfer_protocol: TransferProtocolType,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .update_firmware_simple_update(image_uri, targets, transfer_protocol)
-                .await
-        })
-    }
-
-    fn enable_rshim_bmc<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_rshim_bmc().await })
-    }
-
-    fn clear_nvram<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.clear_nvram().await })
-    }
-
-    fn get_nic_mode<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<NicMode>, RedfishError>> {
-        Box::pin(async move { self.s.get_nic_mode().await })
-    }
-
-    fn set_nic_mode<'a>(
-        &'a self,
-        mode: NicMode,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_nic_mode(mode).await })
-    }
-
-    fn enable_infinite_boot<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.enable_infinite_boot().await })
-    }
-
-    fn is_infinite_boot_enabled<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move { self.s.is_infinite_boot_enabled().await })
-    }
-
-    fn set_host_rshim<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_rshim(enabled).await })
-    }
-
-    fn get_host_rshim<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<EnabledDisabled>, RedfishError>> {
-        Box::pin(async move { self.s.get_host_rshim().await })
-    }
-
-    fn set_idrac_lockdown<'a>(
-        &'a self,
-        enabled: EnabledDisabled,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_idrac_lockdown(enabled).await })
-    }
-
-    fn get_boss_controller<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_boss_controller().await })
-    }
-
-    fn decommission_storage_controller<'a>(
-        &'a self,
-        controller_id: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.decommission_storage_controller(controller_id).await })
-    }
-
-    fn create_storage_volume<'a>(
-        &'a self,
-        controller_id: &'a str,
-        volume_name: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .create_storage_volume(controller_id, volume_name)
-                .await
-        })
     }
 
     fn is_boot_order_setup<'a>(
@@ -1195,107 +701,6 @@ impl Redfish for Bmc {
             let diffs = self.diff_bios_bmc_attr().await?;
             Ok(diffs.is_empty())
         })
-    }
-
-    fn get_component_integrities<'a>(
-        &'a self,
-    ) -> crate::RedfishFuture<'a, Result<ComponentIntegrities, RedfishError>> {
-        Box::pin(async move { self.s.get_component_integrities().await })
-    }
-
-    fn get_firmware_for_component<'a>(
-        &'a self,
-        componnent_integrity_id: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::software_inventory::SoftwareInventory, RedfishError>,
-    > {
-        Box::pin(async move {
-            self.s
-                .get_firmware_for_component(componnent_integrity_id)
-                .await
-        })
-    }
-
-    fn get_component_ca_certificate<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<
-        'a,
-        Result<crate::model::component_integrity::CaCertificate, RedfishError>,
-    > {
-        Box::pin(async move { self.s.get_component_ca_certificate(url).await })
-    }
-
-    fn trigger_evidence_collection<'a>(
-        &'a self,
-        url: &'a str,
-        nonce: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<Task, RedfishError>> {
-        Box::pin(async move { self.s.trigger_evidence_collection(url, nonce).await })
-    }
-
-    fn get_evidence<'a>(
-        &'a self,
-        url: &'a str,
-    ) -> crate::RedfishFuture<'a, Result<crate::model::component_integrity::Evidence, RedfishError>>
-    {
-        Box::pin(async move { self.s.get_evidence(url).await })
-    }
-
-    fn set_host_privilege_level<'a>(
-        &'a self,
-        level: HostPrivilegeLevel,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_host_privilege_level(level).await })
-    }
-
-    fn set_utc_timezone<'a>(&'a self) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_utc_timezone().await })
-    }
-
-    fn get_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<bool>, RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .get_spx_nic_east_west_control_enabled(nic_index)
-                .await
-        })
-    }
-
-    fn set_spx_nic_east_west_control_enabled<'a>(
-        &'a self,
-        nic_index: u8,
-        enabled: bool,
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move {
-            self.s
-                .set_spx_nic_east_west_control_enabled(nic_index, enabled)
-                .await
-        })
-    }
-
-    fn get_spx_nic_mac_address<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<String>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_mac_address(nic_index).await })
-    }
-
-    fn get_spx_nic_model_and_name<'a>(
-        &'a self,
-        nic_index: u8,
-    ) -> crate::RedfishFuture<'a, Result<Option<crate::SpxNicModelAndName>, RedfishError>> {
-        Box::pin(async move { self.s.get_spx_nic_model_and_name(nic_index).await })
-    }
-
-    fn set_ntp_servers<'a>(
-        &'a self,
-        servers: &'a [String],
-    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
-        Box::pin(async move { self.s.set_manager_ntp_servers(servers).await })
     }
 }
 


### PR DESCRIPTION
## Summary

Move standard behavior into default `Redfish` trait implementations and remove ~950 forwarding methods from vendor clients.

Each implementation now exposes its existing `RedfishStandard` through `std_redfish()`. OEM overrides remain unchanged.
