### PR TITLE
fix: skip AMI refinement for identified Viking systems

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -367,7 +367,7 @@ impl RedfishClientPool {
         // - P3809 is a placeholder — pick the GBx variant from chassis contents,
         //   whether it was auto-detected or explicitly provided.
         // - AMI is shared by Viking/DGX/GB300, distinguished by inspecting the
-        //   host systems (see `refine_ami_vendor`).
+        //   selected system and manager or the host systems.
         let vendor = match vendor {
             RedfishVendor::P3809 => {
                 if chassis.contains(&"MGX_NVSwitch_0".to_string()) {
@@ -383,10 +383,12 @@ impl RedfishClientPool {
         s.set_vendor(vendor).await
     }
 
-    /// Refine a service-root `AMI` vendor to `LenovoGB300` when the host is a
-    /// Lenovo system alongside an NVIDIA GB300 baseboard; other AMI platforms
-    /// (Viking/DGX, plain AMI) stay `AMI`.
+    /// Keep known Viking systems as AMI; otherwise detect Lenovo GB300.
     async fn refine_ami_vendor(s: &RedfishStandard) -> Result<RedfishVendor, RedfishError> {
+        if s.system_id() == "DGX" && s.manager_id() == "BMC" {
+            return Ok(RedfishVendor::AMI);
+        }
+
         let mut is_lenovo = false;
         let mut is_gb300 = false;
         for id in s.get_systems().await? {


### PR DESCRIPTION
On powered-off DGX H100 systems, `/Systems/HGX_Baseboard_0` returns HTTP 503 because the host BMC cannot communicate with the HMC. `create_client_impl` calls `refine_ami_vendor`, which fetches every system resource and propagates this error, preventing client creation.

This PR short-circuits `refine_ami_vendor` when `system_id == "DGX"` and `manager_id == "BMC"`, the existing Viking qualification. The vendor remains `AMI`, allowing `set_vendor` to construct `nvidia_viking::Bmc` without querying the unavailable HGX resource. Other AMI and Lenovo GB300 detection remains unchanged.

Related issue: https://github.com/NVIDIA/infra-controller/issues/5418