### PR TITLE
fix: support stock Sushy emulator without custom root.json

### DIFF
--- a/src/model/service_root.rs
+++ b/src/model/service_root.rs
@@ -35,6 +35,8 @@ use crate::model;
 pub struct ServiceRoot {
     #[serde(flatten)]
     pub odata: OData,
+    pub id: Option<String>,
+    pub name: Option<String>,
     pub product: Option<String>,
     pub redfish_version: String,
     pub vendor: Option<String>,
@@ -89,10 +91,28 @@ impl ServiceRoot {
     pub fn vendor_string(&self) -> Option<String> {
         // If there is no "Vendor" key in ServiceRoot, look for an "Oem" entry. It will have a
         // single key which is the vendor name.
-        self.vendor.as_ref().cloned().or_else(|| match &self.oem {
-            Some(oem) => oem.keys().next().cloned(),
-            None => None,
-        })
+        self.vendor
+            .as_ref()
+            .cloned()
+            .or_else(|| match &self.oem {
+                Some(oem) => oem.keys().next().cloned(),
+                None => None,
+            })
+            .or_else(|| {
+                // Stock Sushy emulator has no Vendor or Oem fields but uses
+                // "RedvirtService" as its Id. Detect it from Id and Name so
+                // auto-detection works without a custom root.json template.
+                let haystack = [self.id.as_deref(), self.name.as_deref()];
+                let is_sushy = haystack.iter().flatten().any(|s| {
+                    let lower = s.to_lowercase();
+                    lower.contains("sushy") || lower.contains("redvirt")
+                });
+                if is_sushy {
+                    Some("Sushy".to_string())
+                } else {
+                    None
+                }
+            })
     }
 
     pub fn vendor(&self) -> Option<RedfishVendor> {
@@ -211,5 +231,44 @@ mod test {
             ..Default::default()
         };
         assert_eq!(result.vendor().unwrap(), RedfishVendor::DeltaPowerShelf);
+    }
+
+    #[test]
+    fn test_sushy_detected_from_vendor_field() {
+        let result = ServiceRoot {
+            vendor: Some("Sushy".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::Sushy);
+    }
+
+    #[test]
+    fn test_sushy_detected_from_id_fallback() {
+        // Stock Sushy 2.2.0 has no Vendor field but uses "RedvirtService" as Id.
+        let result = ServiceRoot {
+            id: Some("RedvirtService".to_string()),
+            name: Some("Redvirt Service".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::Sushy);
+    }
+
+    #[test]
+    fn test_sushy_detected_from_name_fallback() {
+        let result = ServiceRoot {
+            name: Some("Sushy Service".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::Sushy);
+    }
+
+    #[test]
+    fn test_sushy_detected_from_name_when_id_is_generic() {
+        let result = ServiceRoot {
+            id: Some("RootService".to_string()),
+            name: Some("Redvirt Service".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(result.vendor().unwrap(), RedfishVendor::Sushy);
     }
 }

--- a/src/sushy.rs
+++ b/src/sushy.rs
@@ -32,6 +32,7 @@
 //! The aliases "Contoso" and "Redvirt" are also accepted.
 
 use crate::Assembly;
+use reqwest::StatusCode;
 use std::{collections::HashMap, path::Path, time::Duration};
 use tokio::fs::File;
 use tracing::info;
@@ -182,11 +183,27 @@ impl Redfish for Bmc {
         &'a self,
     ) -> crate::RedfishFuture<'a, Result<crate::Status, RedfishError>> {
         Box::pin(async move {
-            info!("Sushy: reporting lockdown as enabled (emulator)");
-            Ok(crate::Status {
-                status: crate::StatusInternal::Enabled,
-                message: "Sushy emulator".to_string(),
-            })
+            Err(RedfishError::NotSupported(
+                "lockdown_status".to_string(),
+            ))
+        })
+    }
+
+    fn get_software_inventories<'a>(
+        &'a self,
+    ) -> crate::RedfishFuture<'a, Result<Vec<String>, RedfishError>> {
+        Box::pin(async move {
+            match self.standard.get_software_inventories().await {
+                Ok(v) => Ok(v),
+                Err(RedfishError::HTTPErrorCode { status_code, .. })
+                    if status_code == StatusCode::NOT_FOUND =>
+                {
+                    Err(RedfishError::NotSupported(
+                        "FirmwareInventory".to_string(),
+                    ))
+                }
+                Err(e) => Err(e),
+            }
         })
     }
 


### PR DESCRIPTION
## Summary

Fixes compatibility with stock upstream sushy-tools (tested against stable 2.2.0 from PyPI). Follow-up to #115.

@s3rj1k reported two issues when running NiCO against vanilla Sushy master:
1. `HTTP 404 Not Found` at `/redfish/v1/UpdateService/FirmwareInventory` ([comment](https://github.com/NVIDIA/libredfish/pull/115#issuecomment-2855375716))
2. Stuck in `HOSTINITIALIZING/WAITINGFORLOCKDOWN` regardless of admin-cli input ([comment](https://github.com/NVIDIA/libredfish/pull/115#issuecomment-2855503296))

Investigation revealed a third issue: stock Sushy has no `Vendor` field in the service root, so vendor auto-detection fails entirely — libredfish falls back to the generic `RedfishStandard` client instead of the Sushy vendor implementation.

### Root causes and fixes

**1. Vendor auto-detection (`service_root.rs`)**

Stock Sushy 2.2.0 has no `Vendor` or `Oem` fields in the service root JSON, but uses `"Id": "RedvirtService"` and `"Name": "Redvirt Service"`. Added `id` and `name` fields to `ServiceRoot` and extended `vendor_string()` with a third fallback that detects "sushy" or "redvirt" in those fields.

Previously, without a custom `root.json` template that injects `"Vendor": "Sushy"`, libredfish resolved the vendor as `Unknown` and used the generic standard client — none of the Sushy-specific stubs applied.

**2. `lockdown_status` stuck in WAITINGFORLOCKDOWN (`sushy.rs`)**

The Sushy vendor returned `Ok(Status::Enabled)` for `lockdown_status`, faking a successful lockdown. Callers then believed the machine was locked down and waited for a state transition that could never happen. Changed to return `Err(RedfishError::NotSupported("lockdown_status"))`, matching the `RedfishStandard` default for unsupported operations.

**3. `FirmwareInventory` 404 (`sushy.rs`)**

Stock Sushy 2.2.0 advertises `FirmwareInventory` in the `UpdateService` JSON body but doesn't implement the route handler (added in unreleased dev builds). The standard `get_software_inventories` call hits a raw 404. Added an override that tries the standard path first and converts a 404 into `NotSupported`. When the route exists (e.g. Metal3 dev builds with the controller), it works normally.

## Test plan

- [x] Unit tests: 3 new tests for Sushy vendor detection (explicit field, Id fallback, Name fallback)
- [x] Full test suite passes (144 tests, 0 failures)
- [x] Live tested against stock sushy-tools 2.2.0 (PyPI) in a container — no custom root.json, no patches
- [x] Live tested against Metal3 dev build (0.0.1.dev405) with custom root.json — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)