### PR TITLE
chore: post-transfer repoint (action owner + Cargo.toml URL)

### DIFF
--- a/.github/workflows/stale-check.yml
+++ b/.github/workflows/stale-check.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 10
     steps:
-      - uses: NVIDIA/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
+      - uses: dsx-ai-factory/dsx-github-actions/.github/actions/stale-check@d064e8779c341b8966dc811b2ae375c14b378738
         # Refer to https://github.com/NVIDIA/dsx-github-actions/blob/main/docs/actions/stale-check.md for more details
         with:
           days-before-issue-stale: '60'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "NVIDIA Engineering <noemail@nvidia.com>",
   "Chris Holcombe <xfactor973@gmail.com>",
 ]
-repository = "https://github.com/NVIDIA/libredfish"
+repository = "https://github.com/dsx-ai-factory/libredfish"
 license = "MIT"
 # Version is managed via git tags, see GitHub Releases
 version = "0.0.0"


### PR DESCRIPTION
Post-transfer cleanup after the SCM move to dsx-ai-factory:

- `.github/workflows/stale-check.yml`: repoint the `dsx-github-actions` action reference from `NVIDIA/` to `dsx-ai-factory/` (same pinned SHA). Step-level `uses:` follows the redirect, but pinning the canonical owner avoids relying on it.
- `Cargo.toml`: repoint `repository` URL from `NVIDIA/libredfish` to `dsx-ai-factory/libredfish`.

Non-urgent (GitHub redirects keep both resolving), fixes stale references after the transfer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository metadata to reference the new project location.
  * Updated the stale-check automation to use the corresponding action repository.
  * Preserved existing workflow revisions, configuration, and package features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->