### PR TITLE
feat: prefer NVIDIA DPU reset for force restart

### DIFF
--- a/src/model/chassis.rs
+++ b/src/model/chassis.rs
@@ -38,6 +38,8 @@ use crate::RedfishError;
 pub struct ChassisActions {
     #[serde(rename = "#Chassis.Reset")]
     pub chassis_reset: Option<ChassisAction>,
+    #[serde(rename = "Oem")]
+    pub oem: Option<super::oem::nvidia_openbmc::ChassisOemActions>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/model/oem/nvidia_openbmc.rs
+++ b/src/model/oem/nvidia_openbmc.rs
@@ -21,6 +21,17 @@ pub struct ChassisExtensions {
     pub revision_id: Option<i32>,                        // GB200
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ChassisOemActions {
+    #[serde(rename = "#NvidiaChassis.Reset")]
+    pub reset: Option<NvidiaChassisResetAction>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NvidiaChassisResetAction {
+    pub target: Option<String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, Eq, PartialEq)]
 pub enum BackgroundCopyStatus {
     InProgress,

--- a/src/nvidia_dpu.rs
+++ b/src/nvidia_dpu.rs
@@ -45,7 +45,7 @@ use crate::{
         BootOption,
     },
     standard::RedfishStandard,
-    BiosProfileType, NetworkDeviceFunction, Redfish, RedfishError,
+    BiosProfileType, Chassis, NetworkDeviceFunction, Redfish, RedfishError, SystemPowerControl,
 };
 use crate::{EnabledDisabled, MachineSetupDiff, MachineSetupStatus};
 
@@ -72,7 +72,48 @@ impl Bmc {
     pub fn new(s: RedfishStandard) -> Result<Bmc, RedfishError> {
         Ok(Bmc { s })
     }
+
+    async fn try_force_dpu_reset(&self) -> Result<bool, RedfishError> {
+        let chassis_ids = self.s.get_members("Chassis").await?;
+        let Some(chassis_id) = matching_chassis_id(self.s.system_id(), &chassis_ids) else {
+            return Ok(false);
+        };
+
+        let url = format!("Chassis/{chassis_id}");
+        let (_, chassis): (_, Chassis) = self.s.client.get(&url).await?;
+        let Some(target) = nvidia_force_dpu_reset_target(&chassis) else {
+            return Ok(false);
+        };
+        let target = target
+            .strip_prefix(&format!("/{}/", crate::REDFISH_ENDPOINT))
+            .unwrap_or(target);
+        let data = HashMap::from([("ResetType", "ForceDpuReset")]);
+        match self.s.client.post(target, data).await {
+            Ok(_) => Ok(true),
+            Err(error) if error.not_found() => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
 }
+
+fn matching_chassis_id<'a>(system_id: &str, chassis_ids: &'a [String]) -> Option<&'a str> {
+    chassis_ids.iter().find_map(|chassis_id| {
+        (chassis_id.rsplit('/').next() == Some(system_id)).then_some(chassis_id.as_str())
+    })
+}
+
+fn nvidia_force_dpu_reset_target(chassis: &Chassis) -> Option<&str> {
+    chassis
+        .actions
+        .as_ref()?
+        .oem
+        .as_ref()?
+        .reset
+        .as_ref()?
+        .target
+        .as_deref()
+}
+
 impl Redfish for Bmc {
     fn std_redfish(&self) -> &RedfishStandard {
         &self.s
@@ -88,6 +129,19 @@ impl Redfish for Bmc {
 
     fn ac_powercycle_supported_by_power(&self) -> bool {
         false
+    }
+
+    fn power<'a>(
+        &'a self,
+        action: SystemPowerControl,
+    ) -> crate::RedfishFuture<'a, Result<(), RedfishError>> {
+        Box::pin(async move {
+            if action == SystemPowerControl::ForceRestart && self.try_force_dpu_reset().await? {
+                return Ok(());
+            }
+
+            self.s.power(action).await
+        })
     }
 
     fn get_thermal_metrics<'a>(
@@ -907,5 +961,63 @@ impl Bmc {
         let url = format!("Systems/{}/Oem/Nvidia/Actions/Mode.Set", self.s.system_id());
 
         self.s.client.post(&url, data).await.map(|_resp| Ok(()))?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn matching_chassis_requires_the_system_id() {
+        let cases = [
+            (
+                "matching BlueField-4 chassis",
+                "BlueField_0",
+                vec!["BMC_0".to_string(), "BlueField_0".to_string()],
+                Some("BlueField_0"),
+            ),
+            (
+                "BlueField-3 chassis uses a different id",
+                "Bluefield",
+                vec!["Bluefield_BMC".to_string(), "Card1".to_string()],
+                None,
+            ),
+        ];
+
+        for (name, system_id, chassis_ids, expected) in cases {
+            assert_eq!(
+                matching_chassis_id(system_id, &chassis_ids),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn nvidia_force_dpu_reset_requires_an_advertised_target() {
+        let cases = [
+            (
+                "advertised action",
+                json!({
+                    "Actions": {
+                        "Oem": {
+                            "#NvidiaChassis.Reset": {
+                                "target": "/redfish/v1/Chassis/BlueField_0/Actions/Oem/NvidiaChassis.Reset"
+                            }
+                        }
+                    }
+                }),
+                Some("/redfish/v1/Chassis/BlueField_0/Actions/Oem/NvidiaChassis.Reset"),
+            ),
+            ("missing OEM action", json!({ "Actions": {} }), None),
+        ];
+
+        for (name, payload, expected) in cases {
+            let chassis: Chassis = serde_json::from_value(payload).expect(name);
+            assert_eq!(nvidia_force_dpu_reset_target(&chassis), expected, "{name}");
+        }
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -66,6 +66,8 @@ const NVIDIA_VERA_RUBIN_PORT: &str = "8745";
 const NVIDIA_GBSWITCH_PORT: &str = "8742";
 const LITEON_POWERSHELF_PORT: &str = "8743";
 const DELTA_POWERSHELF_PORT: &str = "8744";
+const NVIDIA_DPU_FORCE_RESET_PORT: &str = "8746";
+const NVIDIA_DPU_STALE_FORCE_RESET_PORT: &str = "8747";
 
 static SETUP: Once = Once::new();
 
@@ -182,6 +184,60 @@ async fn test_delta_powershelf() -> Result<(), anyhow::Error> {
     run_integration_test("delta_powershelf", DELTA_POWERSHELF_PORT).await
 }
 
+#[tokio::test]
+async fn test_nvidia_dpu_force_reset() -> Result<(), anyhow::Error> {
+    let _mockup_server =
+        match run_mockup_server("nvidia_dpu_force_reset", NVIDIA_DPU_FORCE_RESET_PORT) {
+            Ok(server) => server,
+            Err(error) => {
+                tracing::info!("Skipping integration test, env error {error}");
+                return Ok(());
+            }
+        };
+    let endpoint = libredfish::Endpoint {
+        host: format!("127.0.0.1:{NVIDIA_DPU_FORCE_RESET_PORT}"),
+        ..Default::default()
+    };
+    let pool = libredfish::RedfishClientPool::builder()
+        .danger_accept_invalid_certs()
+        .build()?;
+    let redfish = pool.create_client(endpoint).await?;
+
+    redfish
+        .power(libredfish::SystemPowerControl::ForceRestart)
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_nvidia_dpu_stale_force_reset_falls_back() -> Result<(), anyhow::Error> {
+    let _mockup_server = match run_mockup_server(
+        "nvidia_dpu_stale_force_reset",
+        NVIDIA_DPU_STALE_FORCE_RESET_PORT,
+    ) {
+        Ok(server) => server,
+        Err(error) => {
+            tracing::info!("Skipping integration test, env error {error}");
+            return Ok(());
+        }
+    };
+    let endpoint = libredfish::Endpoint {
+        host: format!("127.0.0.1:{NVIDIA_DPU_STALE_FORCE_RESET_PORT}"),
+        ..Default::default()
+    };
+    let pool = libredfish::RedfishClientPool::builder()
+        .danger_accept_invalid_certs()
+        .build()?;
+    let redfish = pool.create_client(endpoint).await?;
+
+    redfish
+        .power(libredfish::SystemPowerControl::ForceRestart)
+        .await?;
+
+    Ok(())
+}
+
 async fn nvidia_dpu_integration_test(redfish: &dyn Redfish) -> Result<(), anyhow::Error> {
     let vendor = redfish.get_service_root().await?.vendor;
     assert!(vendor.is_some() && vendor.unwrap() == "Nvidia");
@@ -238,6 +294,12 @@ async fn nvidia_dpu_integration_test(redfish: &dyn Redfish) -> Result<(), anyhow
         chassis.serial_number.as_ref().unwrap().trim(),
         system.serial_number.as_ref().unwrap().trim()
     );
+
+    // BlueField-3 has no chassis whose ID matches the ComputerSystem ID, so
+    // ForceRestart must retain the standard ComputerSystem.Reset fallback.
+    redfish
+        .power(libredfish::SystemPowerControl::ForceRestart)
+        .await?;
 
     let certificates = redfish.get_secure_boot_certificates("db").await?;
     assert!(!certificates.is_empty());

--- a/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Chassis/BlueField_0/index.json
+++ b/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Chassis/BlueField_0/index.json
@@ -1,0 +1,14 @@
+{
+    "@odata.id": "/redfish/v1/Chassis/BlueField_0",
+    "@odata.type": "#Chassis.v1_22_0.Chassis",
+    "Actions": {
+        "Oem": {
+            "#NvidiaChassis.Reset": {
+                "target": "/redfish/v1/Chassis/BlueField_0/Actions/Oem/NvidiaChassis.Reset"
+            }
+        }
+    },
+    "ChassisType": "Card",
+    "Id": "BlueField_0",
+    "Name": "BlueField_0"
+}

--- a/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Chassis/index.json
+++ b/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Chassis/index.json
@@ -1,0 +1,9 @@
+{
+    "@odata.id": "/redfish/v1/Chassis",
+    "@odata.type": "#ChassisCollection.ChassisCollection",
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/BlueField_0"
+        }
+    ]
+}

--- a/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Managers/index.json
+++ b/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Managers/index.json
@@ -1,0 +1,9 @@
+{
+    "@odata.id": "/redfish/v1/Managers",
+    "@odata.type": "#ManagerCollection.ManagerCollection",
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC_0"
+        }
+    ]
+}

--- a/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Systems/BlueField_0/index.json
+++ b/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Systems/BlueField_0/index.json
@@ -1,0 +1,6 @@
+{
+    "@odata.id": "/redfish/v1/Systems/BlueField_0",
+    "@odata.type": "#ComputerSystem.v1_22_0.ComputerSystem",
+    "Id": "BlueField_0",
+    "Name": "BlueField_0"
+}

--- a/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Systems/index.json
+++ b/tests/mockups/nvidia_dpu_force_reset/redfish/v1/Systems/index.json
@@ -1,0 +1,9 @@
+{
+    "@odata.id": "/redfish/v1/Systems",
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/BlueField_0"
+        }
+    ]
+}

--- a/tests/mockups/nvidia_dpu_force_reset/redfish/v1/index.json
+++ b/tests/mockups/nvidia_dpu_force_reset/redfish/v1/index.json
@@ -1,0 +1,16 @@
+{
+    "@odata.id": "/redfish/v1",
+    "@odata.type": "#ServiceRoot.v1_15_0.ServiceRoot",
+    "Chassis": {
+        "@odata.id": "/redfish/v1/Chassis"
+    },
+    "Managers": {
+        "@odata.id": "/redfish/v1/Managers"
+    },
+    "Product": "BlueField-4 DPU",
+    "RedfishVersion": "1.17.0",
+    "Systems": {
+        "@odata.id": "/redfish/v1/Systems"
+    },
+    "Vendor": "Nvidia"
+}

--- a/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Chassis/BlueField_0/index.json
+++ b/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Chassis/BlueField_0/index.json
@@ -1,0 +1,14 @@
+{
+    "@odata.id": "/redfish/v1/Chassis/BlueField_0",
+    "@odata.type": "#Chassis.v1_22_0.Chassis",
+    "Actions": {
+        "Oem": {
+            "#NvidiaChassis.Reset": {
+                "target": "/redfish/v1/Chassis/Stale/Actions/Oem/NvidiaChassis.Reset"
+            }
+        }
+    },
+    "ChassisType": "Card",
+    "Id": "BlueField_0",
+    "Name": "BlueField_0"
+}

--- a/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Chassis/index.json
+++ b/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Chassis/index.json
@@ -1,0 +1,9 @@
+{
+    "@odata.id": "/redfish/v1/Chassis",
+    "@odata.type": "#ChassisCollection.ChassisCollection",
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/BlueField_0"
+        }
+    ]
+}

--- a/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Managers/index.json
+++ b/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Managers/index.json
@@ -1,0 +1,9 @@
+{
+    "@odata.id": "/redfish/v1/Managers",
+    "@odata.type": "#ManagerCollection.ManagerCollection",
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC_0"
+        }
+    ]
+}

--- a/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Systems/BlueField_0/index.json
+++ b/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Systems/BlueField_0/index.json
@@ -1,0 +1,11 @@
+{
+    "@odata.id": "/redfish/v1/Systems/BlueField_0",
+    "@odata.type": "#ComputerSystem.v1_22_0.ComputerSystem",
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/BlueField_0/Actions/ComputerSystem.Reset"
+        }
+    },
+    "Id": "BlueField_0",
+    "Name": "BlueField_0"
+}

--- a/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Systems/index.json
+++ b/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/Systems/index.json
@@ -1,0 +1,9 @@
+{
+    "@odata.id": "/redfish/v1/Systems",
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/BlueField_0"
+        }
+    ]
+}

--- a/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/index.json
+++ b/tests/mockups/nvidia_dpu_stale_force_reset/redfish/v1/index.json
@@ -1,0 +1,16 @@
+{
+    "@odata.id": "/redfish/v1",
+    "@odata.type": "#ServiceRoot.v1_15_0.ServiceRoot",
+    "Chassis": {
+        "@odata.id": "/redfish/v1/Chassis"
+    },
+    "Managers": {
+        "@odata.id": "/redfish/v1/Managers"
+    },
+    "Product": "BlueField-4 DPU",
+    "RedfishVersion": "1.17.0",
+    "Systems": {
+        "@odata.id": "/redfish/v1/Systems"
+    },
+    "Vendor": "Nvidia"
+}


### PR DESCRIPTION
Using the "/redfish/v1/Chassis/BlueField_0/Actions/Oem/NvidiaChassis.Reset" endpoint is the official way for BF4 to do the reset.
The standard redfish ForceRestart method may not work with BF4 DPU.
To handle this situation, the nv-redfish would try to use "/redfish/v1/Chassis/BlueField_0/Actions/Oem/NvidiaChassis.Reset" endpoint first to reset the BF4 DPU if the endpoint exists. If the endpoint does not exist, the nv-redfish would be fallback to standard ForceRestart method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added NVIDIA DPU force-restart support using the advertised chassis reset action when available.
  - Added automatic fallback to the standard reset operation when the specialized action is unavailable or the matching chassis cannot be found.
  - Added support for recognizing NVIDIA OEM chassis reset actions and their targets.

- **Tests**
  - Added coverage for successful NVIDIA force resets, chassis matching, reset-target discovery, and fallback behavior when reset targets are stale or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->